### PR TITLE
chore: fix transaction json scrolling

### DIFF
--- a/src/features/layout/pages/layout-page.tsx
+++ b/src/features/layout/pages/layout-page.tsx
@@ -14,7 +14,7 @@ export function LayoutPage({ children }: LayoutPageProps) {
   return (
     <>
       <Header className={cn('mb-1')} />
-      <div className={cn('flex h-full flex-shrink flex-row')}>
+      <div className={cn('flex h-full flex-row')}>
         <LeftSideBarMenu />
         <div className={cn('pl-4 pt-4')}> {children}</div>
       </div>

--- a/src/features/transactions/components/transaction-json.tsx
+++ b/src/features/transactions/components/transaction-json.tsx
@@ -9,8 +9,8 @@ export function TransactionJson({ transaction }: Props) {
   return (
     <div className={cn('space-y-2')}>
       <h2 className={cn('text-xl font-bold')}>Transction JSON</h2>
-      <div className={cn('border-solid border-2 border-border h-96 p-4 overflow-y-scroll')}>
-        <pre>{JSON.stringify(transaction, null, 4)}</pre>
+      <div className={cn('border-solid border-2 border-border h-96 grid')}>
+        <pre className={cn('overflow-scroll p-4')}>{JSON.stringify(transaction, null, 4)}</pre>
       </div>
     </div>
   )


### PR DESCRIPTION
Fix the bug where viewing transaction `ILDCD5Z64CYSLEZIHBG5DVME2ITJI2DIVZAPDPEWPCYMTRA5SVGA` cause the screen to be overflown.
After this PR, the transaction JSON is wrapped nicely.
![image](https://github.com/MakerXStudio/algokit-explorer/assets/1898267/690f110a-7b3a-4a77-acaf-08ccbdde0ff4)
