### PR TITLE
chore: fix macos build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,7 +79,7 @@ jobs:
     strategy:
       matrix:
         # macos-14 is the Apple Silicon M1 runner
-        platform: [ubuntu-20.04, windows-latest, 'macos-latest', 'macos-14']
+        platform: [ubuntu-20.04, windows-latest, 'macos-12', 'macos-14']
     if: ${{ needs.create-release.outputs.release-published == 'true' }}
 
     steps:


### PR DESCRIPTION
`macos-latest` points to `macos-14` now, which is an ARM agent. I have dropped to `macos-12` which in the oldest intel agent, than isn't slated for deprecation.

Fixes https://github.com/MakerXStudio/algokit-explorer/actions/runs/9072311470/job/24927629501