### PR TITLE
fix: chore subscriber-ts tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "algokit-explorer",
       "version": "0.0.0",
       "dependencies": {
-        "@algorandfoundation/algokit-subscriber": "^1.3.0-beta.3",
-        "@algorandfoundation/algokit-utils": "^6.0.0-beta.1",
+        "@algorandfoundation/algokit-subscriber": "^1.3.0-beta.6",
+        "@algorandfoundation/algokit-utils": "^6.0.4",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-icons": "^1.3.0",
@@ -103,9 +103,9 @@
       }
     },
     "node_modules/@algorandfoundation/algokit-subscriber": {
-      "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-subscriber/-/algokit-subscriber-1.3.0-beta.3.tgz",
-      "integrity": "sha512-kaQlT6/i9mjjoWpY98Z077Cp+Y0wZH3lvtZZsLR2OzSNQUSFwVCGGVjexXXmlJ9F9gG3aKbmZP6aq5oVqZz7Sw==",
+      "version": "1.3.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-subscriber/-/algokit-subscriber-1.3.0-beta.6.tgz",
+      "integrity": "sha512-jag03FvYHxE6nR5iblrl7ysVUzLb7sNDSUZ0olV9znS1fw+czTnEkYYKW0NZRjj+gv3xiOYHseMPPk2PKrRs4Q==",
       "dependencies": {
         "algorand-msgpack": "^1.0.1",
         "buffer": "^6.0.3",
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@algorandfoundation/algokit-utils": {
-      "version": "6.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-utils/-/algokit-utils-6.0.0-beta.2.tgz",
-      "integrity": "sha512-36dW/UusaHdc1zxuETZ6JNkJZ67DFyU2Rr4hWJnGl+2izj+m9HrNTHTZWf9g3RmNvLVwKJx5+e8H80ry5v5WAA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-utils/-/algokit-utils-6.0.4.tgz",
+      "integrity": "sha512-Vk0OC6X3KaKw+tFkI2YZGF3DK2PZ/+eIfVBiF8pp5LLUegNc8yoHvifv0RM+t6loDY3q8agSdj4/lsL9FDhrgw==",
       "dependencies": {
         "buffer": "^6.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "pre-commit": "run-s check-types lint:fix audit test"
   },
   "dependencies": {
-    "@algorandfoundation/algokit-subscriber": "^1.3.0-beta.3",
-    "@algorandfoundation/algokit-utils": "^6.0.0-beta.1",
+    "@algorandfoundation/algokit-subscriber": "^1.3.0-beta.6",
+    "@algorandfoundation/algokit-utils": "^6.0.4",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-icons": "^1.3.0",


### PR DESCRIPTION
- Prevent double status calls when polling for blocks (fixed in subscriber-ts)
- Handle refreshing accounts when assets are created or destroyed (partially added in subscriber-ts)