### PR TITLE
chore: only render the top level to increase performance on larger JSON

### DIFF
--- a/src/features/common/components/json-view.tsx
+++ b/src/features/common/components/json-view.tsx
@@ -34,11 +34,6 @@ export function JsonView({ json }: { json: object }) {
     toast.success('JSON copied to clipboard')
   }, [json])
 
-  // Only render the top level because sometimes the object has too many children to render
-  const shouldExpandNode = useCallback((level: number) => {
-    return level < 1
-  }, [])
-
   return (
     <div className={cn('overflow-auto relative p-2')}>
       <Button className={cn('absolute top-4 right-4')} onClick={copyJsonToClipboard}>
@@ -47,6 +42,10 @@ export function JsonView({ json }: { json: object }) {
       <ReactJsonView data={json} shouldExpandNode={shouldExpandNode} style={style} />
     </div>
   )
+}
+// Only render the top level because sometimes the object has too many children to render
+const shouldExpandNode = (level: number) => {
+  return level < 1
 }
 
 export interface StyleProps {


### PR DESCRIPTION
chore: only render the top level to increase performance on larger JSON:
- It takes 2-3 seconds to open the account EHYQCYHUC6CIWZLBX5TDTLVJ4SSVE4RRTMKFDCG4Z4Q7QSQ2XWIQPMKBPU on my PC
- Expanding the assets or createdAssets list take 5-7 seconds