### PR TITLE
chore: release website

### DIFF
--- a/.github/workflows/release-web.yaml
+++ b/.github/workflows/release-web.yaml
@@ -58,11 +58,6 @@ jobs:
           name: website
           path: artifacts
 
-      - name: Display structure of downloaded files
-        run: |
-          cd artifacts
-          ls -R
-
       - name: Unzip
         run: |
           cd artifacts
@@ -89,11 +84,6 @@ jobs:
         with:
           name: website
           path: artifacts
-
-      - name: Display structure of downloaded files
-        run: |
-          cd artifacts
-          ls -R
 
       - name: Unzip
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,11 +139,6 @@ jobs:
           name: website
           path: artifacts
 
-      - name: Display structure of downloaded files
-        run: |
-          cd artifacts
-          ls -R
-
       - name: Unzip
         run: |
           cd artifacts


### PR DESCRIPTION
chore: release website
- disable Tauri build and release
- create the job to deploy to production