### PR TITLE
chore: reset state if time between subscriber failure and restart is too long

### DIFF
--- a/src/features/blocks/data/latest-blocks.ts
+++ b/src/features/blocks/data/latest-blocks.ts
@@ -273,7 +273,11 @@ const subscriberAtom = atom(null, (get, set) => {
   })
 
   subscriber.onError((e) => {
-    set(subscriberStatusAtom, { state: SubscriberState.Failed, error: asError(e) } satisfies SubscriberStatus)
+    set(subscriberStatusAtom, {
+      state: SubscriberState.Failed,
+      error: asError(e),
+      timestamp: createTimestamp(),
+    } satisfies SubscriberStatus)
     // eslint-disable-next-line no-console
     console.error(e)
   })

--- a/src/features/blocks/data/types.ts
+++ b/src/features/blocks/data/types.ts
@@ -27,4 +27,5 @@ export type SubscriberStatus =
   | {
       state: SubscriberState.Failed
       error: Error
+      timestamp: number
     }

--- a/src/features/common/data/state-cleanup.ts
+++ b/src/features/common/data/state-cleanup.ts
@@ -9,12 +9,12 @@ import { applicationResultsAtom } from '@/features/applications/data'
 import { assetMetadataResultsAtom, assetResultsAtom } from '@/features/assets/data'
 
 const cleanUpIntervalMillis = 600_000 // 10 minutes
-const expirationMillis = 1_800_000 // 30 minutes
+export const cachedDataExpirationMillis = 1_800_000 // 30 minutes
 // Run every 10 minutes and cleanup data that hasn't been accessed in the last 30 minutes
 
 const stateCleanupEffect = atomEffect((get, set) => {
   const cleanup = setInterval(() => {
-    const expiredTimestamp = Date.now() - expirationMillis
+    const expiredTimestamp = Date.now() - cachedDataExpirationMillis
 
     const removeExpired = createExpiredDataRemover(get, set, expiredTimestamp)
     set(latestTransactionIdsAtom, (prev) => {


### PR DESCRIPTION
There is no need to run a full catchup when the time between subscriber failure and restart is greater than the caching period.