### PR TITLE
fix: handle block with no transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@algorandfoundation/algokit-subscriber": "2.0.0-beta.3",
+        "@algorandfoundation/algokit-subscriber": "^2.0.0-beta.4",
         "@algorandfoundation/algokit-utils": "^6.0.5",
         "@blockshake/defly-connect": "^1.1.6",
         "@daffiwallet/connect": "^1.0.3",
@@ -117,9 +117,9 @@
       }
     },
     "node_modules/@algorandfoundation/algokit-subscriber": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-subscriber/-/algokit-subscriber-2.0.0-beta.3.tgz",
-      "integrity": "sha512-BD/jJ+IBxVt+cEI8L61XRohOh2AznmA6JsgtFHI3I4y+0nCWZpIwB4uGZfZ4hozESukrsEVpt44DbYcowhLrXw==",
+      "version": "2.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-subscriber/-/algokit-subscriber-2.0.0-beta.4.tgz",
+      "integrity": "sha512-w3a6wIJECzDkBBeNAudWLJi1eNksEgMRqv8Rh7M4G0NQn8Sls7AaGQV1O0ebQoUHa72u8ptj5BBzRluljiGuGQ==",
       "dependencies": {
         "algorand-msgpack": "^1.0.1",
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
-    "@algorandfoundation/algokit-subscriber": "2.0.0-beta.3",
+    "@algorandfoundation/algokit-subscriber": "^2.0.0-beta.4",
     "@algorandfoundation/algokit-utils": "^6.0.5",
     "@blockshake/defly-connect": "^1.1.6",
     "@daffiwallet/connect": "^1.0.3",


### PR DESCRIPTION
Updating subscriber to handle blocks with no transactions, as `block.txn` is undefined in this scenario.