### PR TITLE
feat: adjust visual transaction label to better represent friendly names for transactions

### DIFF
--- a/src/features/transactions-graph/components/__snapshots__/application-transaction-graph.DX64C5POMYLPSMOZVQZWF5VJ7RW27THYBUGKNH5T4A5D2KAFHZCQ.html
+++ b/src/features/transactions-graph/components/__snapshots__/application-transaction-graph.DX64C5POMYLPSMOZVQZWF5VJ7RW27THYBUGKNH5T4A5D2KAFHZCQ.html
@@ -716,7 +716,7 @@
             class="z-20 bg-card p-0.5 text-xs text-center"
           >
             <span>
-              App Call
+              App Create
             </span>
           </div>
         </div>
@@ -795,7 +795,7 @@
             class="z-20 bg-card p-0.5 text-xs text-center"
           >
             <span>
-              App Call
+              App Create
             </span>
           </div>
         </div>
@@ -874,7 +874,7 @@
             class="z-20 bg-card p-0.5 text-xs text-center"
           >
             <span>
-              App Call
+              App Create
             </span>
           </div>
         </div>
@@ -953,7 +953,7 @@
             class="z-20 bg-card p-0.5 text-xs text-center"
           >
             <span>
-              App Call
+              App Create
             </span>
           </div>
         </div>
@@ -1032,7 +1032,7 @@
             class="z-20 bg-card p-0.5 text-xs text-center"
           >
             <span>
-              App Call
+              App Create
             </span>
           </div>
         </div>
@@ -1111,7 +1111,7 @@
             class="z-20 bg-card p-0.5 text-xs text-center"
           >
             <span>
-              App Call
+              App Create
             </span>
           </div>
         </div>
@@ -1190,7 +1190,7 @@
             class="z-20 bg-card p-0.5 text-xs text-center"
           >
             <span>
-              App Call
+              App Create
             </span>
           </div>
         </div>
@@ -1269,7 +1269,7 @@
             class="z-20 bg-card p-0.5 text-xs text-center"
           >
             <span>
-              App Call
+              App Create
             </span>
           </div>
         </div>
@@ -1348,7 +1348,7 @@
             class="z-20 bg-card p-0.5 text-xs text-center"
           >
             <span>
-              App Call
+              App Create
             </span>
           </div>
         </div>
@@ -1427,7 +1427,7 @@
             class="z-20 bg-card p-0.5 text-xs text-center"
           >
             <span>
-              App Call
+              App Create
             </span>
           </div>
         </div>
@@ -1506,7 +1506,7 @@
             class="z-20 bg-card p-0.5 text-xs text-center"
           >
             <span>
-              App Call
+              App Create
             </span>
           </div>
         </div>
@@ -1585,7 +1585,7 @@
             class="z-20 bg-card p-0.5 text-xs text-center"
           >
             <span>
-              App Call
+              App Create
             </span>
           </div>
         </div>
@@ -1664,7 +1664,7 @@
             class="z-20 bg-card p-0.5 text-xs text-center"
           >
             <span>
-              App Call
+              App Create
             </span>
           </div>
         </div>
@@ -1743,7 +1743,7 @@
             class="z-20 bg-card p-0.5 text-xs text-center"
           >
             <span>
-              App Call
+              App Create
             </span>
           </div>
         </div>

--- a/src/features/transactions-graph/components/horizontal.tsx
+++ b/src/features/transactions-graph/components/horizontal.tsx
@@ -53,32 +53,47 @@ function Circle({ className, text }: { className?: string; text?: string | numbe
   )
 }
 
-const labelTypeToTextMap = new Map([
-  [LabelType.AssetTransfer, 'Transfer'],
-  [LabelType.AssetTransferRemainder, 'Remainder'],
-  [LabelType.Clawback, 'Clawback'],
-  [LabelType.Payment, 'Payment'],
-  [LabelType.PaymentTransferRemainder, 'Remainder'],
-])
+function VectorLabelText({ type }: { type: LabelType }) {
+  if (type === LabelType.Payment) return <span>Payment</span>
+  if (type === LabelType.AssetTransfer) return <span>Transfer</span>
+  if (type === LabelType.PaymentTransferRemainder || type === LabelType.AssetTransferRemainder) return <span>Remainder</span>
+  if (type === LabelType.AppCall) return <span>App Call</span>
+  if (type === LabelType.AppCreate) return <span>App Create</span>
+  if (type === LabelType.AssetCreate) return <span>Asset Create</span>
+  if (type === LabelType.AssetReconfigure)
+    return (
+      <span>
+        Asset
+        <br />
+        Reconfigure
+      </span>
+    )
+  if (type === LabelType.AssetDestroy)
+    return (
+      <span>
+        Asset
+        <br />
+        Destroy
+      </span>
+    )
+  if (type === LabelType.AssetFreeze) return <span>Asset Freeze</span>
+  if (type === LabelType.KeyReg) return <span>Key Reg</span>
+  if (type === LabelType.StateProof) return <span>State Proof</span>
+  if (type === LabelType.Clawback) return <span>Clawback</span>
+  return undefined
+}
 
 function VectorLabel({ transaction, vector }: { transaction: Transaction | InnerTransaction; vector: Vector }) {
   const colorClass = colorClassMap[transaction.type]
-  if (vector.label.type === LabelType.Payment || vector.label.type === LabelType.PaymentTransferRemainder) {
-    return (
-      <>
-        <span>{labelTypeToTextMap.get(vector.label.type)}</span>
+  return (
+    <>
+      <VectorLabelText type={vector.label.type} />
+      {(vector.label.type === LabelType.Payment || vector.label.type === LabelType.PaymentTransferRemainder) && (
         <DisplayAlgo className="flex justify-center" amount={vector.label.amount} short={true} />
-      </>
-    )
-  }
-  if (
-    vector.label.type === LabelType.AssetTransfer ||
-    vector.label.type === LabelType.AssetTransferRemainder ||
-    vector.label.type === LabelType.Clawback
-  ) {
-    return (
-      <>
-        <span>{labelTypeToTextMap.get(vector.label.type)}</span>
+      )}
+      {(vector.label.type === LabelType.AssetTransfer ||
+        vector.label.type === LabelType.AssetTransferRemainder ||
+        vector.label.type === LabelType.Clawback) && (
         <DisplayAssetAmount
           asset={vector.label.asset}
           amount={vector.label.amount}
@@ -86,26 +101,22 @@ function VectorLabel({ transaction, vector }: { transaction: Transaction | Inner
           linkClassName={colorClass.text}
           short={true}
         />
-      </>
-    )
-  }
-  return <span>{vector.label.type}</span>
+      )}
+    </>
+  )
 }
 
 function SelfLoopLabel({ transaction, loop }: { transaction: Transaction | InnerTransaction; loop: SelfLoop }) {
   const colorClass = colorClassMap[transaction.type]
-  if (loop.label.type === LabelType.Payment || loop.label.type === LabelType.PaymentTransferRemainder) {
-    return (
-      <>
-        <span>{labelTypeToTextMap.get(loop.label.type)}</span>
+  return (
+    <>
+      <VectorLabelText type={loop.label.type} />
+      {(loop.label.type === LabelType.Payment || loop.label.type === LabelType.PaymentTransferRemainder) && (
         <DisplayAlgo className={cn('flex justify-center')} amount={loop.label.amount} short={true} />
-      </>
-    )
-  }
-  if (loop.label.type === LabelType.AssetTransfer || loop.label.type === LabelType.AssetTransferRemainder) {
-    return (
-      <>
-        <span>{labelTypeToTextMap.get(loop.label.type)}</span>
+      )}
+      {(loop.label.type === LabelType.AssetTransfer ||
+        loop.label.type === LabelType.AssetTransferRemainder ||
+        loop.label.type === LabelType.Clawback) && (
         <DisplayAssetAmount
           className={cn('flex justify-center')}
           amount={loop.label.amount}
@@ -113,10 +124,9 @@ function SelfLoopLabel({ transaction, loop }: { transaction: Transaction | Inner
           linkClassName={colorClass.text}
           short={true}
         />
-      </>
-    )
-  }
-  return <span>{loop.label.type}</span>
+      )}
+    </>
+  )
 }
 
 const RenderTransactionVector = fixedForwardRef(

--- a/src/features/transactions-graph/mappers/horizontals.ts
+++ b/src/features/transactions-graph/mappers/horizontals.ts
@@ -2,6 +2,7 @@ import {
   AppCallTransaction,
   AppCallTransactionSubType,
   AssetConfigTransaction,
+  AssetConfigTransactionSubType,
   AssetFreezeTransaction,
   AssetTransferTransaction,
   AssetTransferTransactionSubType,
@@ -109,7 +110,8 @@ const getAppCallTransactionRepresentations = (
           verticalId: verticals.find((c) => c.type === 'Application' && transaction.applicationId === c.applicationId)?.id ?? -1,
         }
 
-  return [asTransactionGraphRepresentation(from, to, { type: LabelType.ApplicationCall })]
+  const type = transaction.action === 'Create' ? LabelType.AppCreate : LabelType.AppCall
+  return [asTransactionGraphRepresentation(from, to, { type })]
 }
 
 const getAssetConfigTransactionRepresentations = (
@@ -124,7 +126,18 @@ const getAssetConfigTransactionRepresentations = (
     verticalId: verticals.find((c) => c.type === 'Asset' && transaction.assetId === c.assetId)?.id ?? -1,
   }
 
-  return [asTransactionGraphRepresentation(from, to, { type: LabelType.AssetConfig })]
+  const type =
+    transaction.subType === AssetConfigTransactionSubType.Reconfigure
+      ? LabelType.AssetReconfigure
+      : transaction.subType === AssetConfigTransactionSubType.Destroy
+        ? LabelType.AssetDestroy
+        : LabelType.AssetCreate
+
+  return [
+    asTransactionGraphRepresentation(from, to, {
+      type,
+    }),
+  ]
 }
 
 const getAssetFreezeTransactionRepresentations = (

--- a/src/features/transactions-graph/mappers/horizontals.ts
+++ b/src/features/transactions-graph/mappers/horizontals.ts
@@ -101,16 +101,15 @@ const getAppCallTransactionRepresentations = (
   const from = parent
     ? calculateFromWithParent(transaction.sender, verticals, parent)
     : calculateFromWithoutParent(transaction.sender, verticals)
-  const to =
-    transaction.subType === AppCallTransactionSubType.OpUp
-      ? {
-          verticalId: verticals.find((c) => c.type === 'OpUp')?.id ?? -1,
-        }
-      : {
-          verticalId: verticals.find((c) => c.type === 'Application' && transaction.applicationId === c.applicationId)?.id ?? -1,
-        }
+  const to = transaction.isOpUp
+    ? {
+        verticalId: verticals.find((c) => c.type === 'OpUp')?.id ?? -1,
+      }
+    : {
+        verticalId: verticals.find((c) => c.type === 'Application' && transaction.applicationId === c.applicationId)?.id ?? -1,
+      }
 
-  const type = transaction.action === 'Create' ? LabelType.AppCreate : LabelType.AppCall
+  const type = transaction.subType === AppCallTransactionSubType.Create ? LabelType.AppCreate : LabelType.AppCall
   return [asTransactionGraphRepresentation(from, to, { type })]
 }
 

--- a/src/features/transactions-graph/mappers/verticals.ts
+++ b/src/features/transactions-graph/mappers/verticals.ts
@@ -1,10 +1,4 @@
-import {
-  AppCallTransactionSubType,
-  AssetTransferTransactionSubType,
-  InnerTransaction,
-  Transaction,
-  TransactionType,
-} from '@/features/transactions/models'
+import { AssetTransferTransactionSubType, InnerTransaction, Transaction, TransactionType } from '@/features/transactions/models'
 import { ApplicationVertical, Vertical } from '../models'
 import { distinct } from '@/utils/distinct'
 import { getApplicationAddress } from 'algosdk'
@@ -167,7 +161,7 @@ const asRawTransactionGraphVerticals = (transaction: Transaction | InnerTransact
     }
   }
   if (transaction.type === TransactionType.AppCall) {
-    if (transaction.subType === AppCallTransactionSubType.OpUp) {
+    if (transaction.isOpUp) {
       verticals.push({
         id: -1,
         type: 'OpUp',

--- a/src/features/transactions-graph/models/index.ts
+++ b/src/features/transactions-graph/models/index.ts
@@ -30,15 +30,18 @@ export enum RepresentationType {
 
 export enum LabelType {
   Payment = 'Payment',
-  PaymentTransferRemainder = 'Payment Transfer Remainder',
-  AssetTransfer = 'Asset Transfer',
-  ApplicationCall = 'App Call',
-  AssetConfig = 'Asset Config',
-  AssetFreeze = 'Asset Freeze',
-  KeyReg = 'Key Reg',
-  StateProof = 'State Proof',
+  PaymentTransferRemainder = 'PaymentTransferRemainder',
+  AssetTransfer = 'AssetTransfer',
+  AssetTransferRemainder = 'AssetTransferRemainder',
+  AppCall = 'AppCall',
+  AppCreate = 'AppCreate',
+  AssetCreate = 'AssetCreate',
+  AssetReconfigure = 'AssetReconfigure',
+  AssetDestroy = 'AssetDestroy',
+  AssetFreeze = 'AssetFreeze',
+  KeyReg = 'KeyReg',
+  StateProof = 'StateProof',
   Clawback = 'Clawback',
-  AssetTransferRemainder = 'Asset Transfer Remainder',
 }
 
 export type Label =
@@ -61,8 +64,11 @@ export type Label =
       amount: number | bigint
     }
   | { type: LabelType.Clawback; asset: AsyncMaybeAtom<AssetSummary>; amount: number | bigint }
-  | { type: LabelType.ApplicationCall }
-  | { type: LabelType.AssetConfig }
+  | { type: LabelType.AppCall }
+  | { type: LabelType.AppCreate }
+  | { type: LabelType.AssetCreate }
+  | { type: LabelType.AssetReconfigure }
+  | { type: LabelType.AssetDestroy }
   | { type: LabelType.AssetFreeze }
   | { type: LabelType.KeyReg }
   | { type: LabelType.StateProof }

--- a/src/features/transactions/components/app-call-transaction-info.tsx
+++ b/src/features/transactions/components/app-call-transaction-info.tsx
@@ -31,7 +31,6 @@ export const localStateDeltaTabLabel = 'Local State Delta'
 
 export const appCallTransactionDetailsLabel = 'App Call Transaction Details'
 export const onCompletionLabel = 'On Completion'
-export const actionLabel = 'Action'
 
 export function AppCallTransactionInfo({ transaction }: Props) {
   const items = useMemo(
@@ -45,15 +44,11 @@ export function AppCallTransactionInfo({ transaction }: Props) {
         dd: <ApplicationLink applicationId={transaction.applicationId} showCopyButton={true} />,
       },
       {
-        dt: actionLabel,
-        dd: transaction.action,
-      },
-      {
         dt: onCompletionLabel,
         dd: transaction.onCompletion,
       },
     ],
-    [transaction.action, transaction.applicationId, transaction.onCompletion, transaction.sender]
+    [transaction.applicationId, transaction.onCompletion, transaction.sender]
   )
   const tabs = useMemo(
     () => [

--- a/src/features/transactions/components/transaction-type-description-details.tsx
+++ b/src/features/transactions/components/transaction-type-description-details.tsx
@@ -1,4 +1,4 @@
-import { InnerTransaction, SignatureType, Transaction } from '@/features/transactions/models'
+import { InnerTransaction, SignatureType, Transaction, TransactionType } from '@/features/transactions/models'
 import { Badge } from '@/features/common/components/badge'
 
 export function TransactionTypeDescriptionDetails({ transaction }: { transaction: Transaction | InnerTransaction }) {
@@ -6,6 +6,7 @@ export function TransactionTypeDescriptionDetails({ transaction }: { transaction
     <div className="flex flex-wrap items-center gap-2">
       <Badge variant={transaction.type}>{transaction.type}</Badge>
       {transaction.subType && <Badge variant="outline">{transaction.subType}</Badge>}
+      {transaction.type === TransactionType.AppCall && transaction.isOpUp && <Badge variant="outline">OpUp</Badge>}
       {transaction.signature?.type === SignatureType.Multi && <Badge variant="outline">Multisig</Badge>}
       {transaction.signature?.type === SignatureType.Logic && <Badge variant="outline">LogicSig</Badge>}
       {transaction.rekeyTo && <Badge variant="outline">Rekey</Badge>}

--- a/src/features/transactions/mappers/app-call-transaction-mappers.ts
+++ b/src/features/transactions/mappers/app-call-transaction-mappers.ts
@@ -43,10 +43,10 @@ const mapCommonAppCallTransactionProperties = (
   indexPrefix?: string
 ) => {
   invariant(transactionResult['application-transaction'], 'application-transaction is not set')
-  const action = transactionResult['application-transaction']['application-id'] ? 'Call' : 'Create'
+  const isCreate = !transactionResult['application-transaction']['application-id']
   const onCompletion = asAppCallOnComplete(transactionResult['application-transaction']['on-completion'])
   const isOpUp =
-    action === 'Create' &&
+    isCreate &&
     onCompletion === AppCallOnComplete.Delete &&
     opUpPrograms.includes(transactionResult['application-transaction']['approval-program']) &&
     opUpPrograms.includes(transactionResult['application-transaction']['clear-state-program'])
@@ -54,7 +54,8 @@ const mapCommonAppCallTransactionProperties = (
   return {
     ...mapCommonTransactionProperties(transactionResult),
     type: TransactionType.AppCall,
-    subType: isOpUp ? AppCallTransactionSubType.OpUp : undefined,
+    subType: isCreate ? AppCallTransactionSubType.Create : undefined,
+    isOpUp,
     applicationId: transactionResult['application-transaction']['application-id']
       ? transactionResult['application-transaction']['application-id']
       : transactionResult['created-application-index']!,
@@ -70,8 +71,7 @@ const mapCommonAppCallTransactionProperties = (
         const innerId = indexPrefix ? `${indexPrefix}/${index + 1}` : `${index + 1}`
         return asInnerTransaction(networkTransactionId, innerId, innerTransaction, assetResolver)
       }) ?? [],
-    onCompletion: onCompletion,
-    action: action,
+    onCompletion,
     logs: transactionResult['logs'] ?? [],
   } satisfies BaseAppCallTransaction
 }

--- a/src/features/transactions/models/index.ts
+++ b/src/features/transactions/models/index.ts
@@ -125,12 +125,13 @@ export type LocalStateDelta = {
 }
 
 export enum AppCallTransactionSubType {
-  OpUp = 'OpUp',
+  Create = 'Create',
 }
 
 export type BaseAppCallTransaction = CommonTransactionProperties & {
   type: TransactionType.AppCall
   subType: AppCallTransactionSubType | undefined
+  isOpUp: boolean
   applicationId: number
   applicationArgs: string[]
   foreignApps: number[]
@@ -140,7 +141,6 @@ export type BaseAppCallTransaction = CommonTransactionProperties & {
   localStateDeltas: LocalStateDelta[]
   innerTransactions: InnerTransaction[]
   onCompletion: AppCallOnComplete
-  action: 'Create' | 'Call'
   logs: string[]
 }
 

--- a/src/features/transactions/pages/transaction-page.test.tsx
+++ b/src/features/transactions/pages/transaction-page.test.tsx
@@ -45,7 +45,6 @@ import { transactionCloseRemainderAmountLabel, transactionCloseRemainderToLabel 
 import { descriptionListAssertion } from '@/tests/assertions/description-list-assertion'
 import { tableAssertion } from '@/tests/assertions/table-assertion'
 import {
-  actionLabel,
   appCallTransactionDetailsLabel,
   foreignAccountsTabLabel,
   applicationArgsTabLabel,
@@ -659,7 +658,6 @@ describe('transaction-page', () => {
                 { term: transactionFeeLabel, description: '0.005' },
                 { term: transactionSenderLabel, description: 'W2IZ3EHDRW2IQNPC33CI2CXSLMFCFICVKQVWIYLJWXCTD765RW47ONNCEY' },
                 { term: applicationIdLabel, description: '971368268' },
-                { term: actionLabel, description: 'Call' },
                 { term: onCompletionLabel, description: 'NoOp' },
               ],
             })
@@ -759,7 +757,6 @@ describe('transaction-page', () => {
                 { term: transactionFeeLabel, description: '0.002' },
                 { term: transactionSenderLabel, description: 'AACCDJTFPQR5UQJZ337NFR56CC44T776EWBGVJG5NY2QFTQWBWTALTEN4A' },
                 { term: applicationIdLabel, description: '1002541853' },
-                { term: actionLabel, description: 'Call' },
                 { term: onCompletionLabel, description: 'NoOp' },
               ],
             })


### PR DESCRIPTION
Completes #148 

- Adjust transaction visualiser labels to better represent the thing that is happening, rather than simply reflection the transaction type
- Adjust app call transaction `subType` and `action` fields to better align with other transaction types.