### PR TITLE
feat: temporary localnet config

### DIFF
--- a/src/features/forms/components/checkbox-form-item.tsx
+++ b/src/features/forms/components/checkbox-form-item.tsx
@@ -26,7 +26,7 @@ export function CheckboxFormItem<TSchema extends Record<string, unknown>>({
         name={field}
         render={({ field: { value, onChange } }) => (
           <div className={cn('ml-0.5 flex items-center space-x-2', className)}>
-            <Checkbox id={field} checked={value} onCheckedChange={onChange} {...rest} />
+            <Checkbox id={field} name={field} checked={value} onCheckedChange={onChange} {...rest} />
             {label && (
               <Label htmlFor={field} aria-invalid={Boolean(error)}>
                 {label}

--- a/src/features/forms/components/multi-select-form-item.tsx
+++ b/src/features/forms/components/multi-select-form-item.tsx
@@ -24,6 +24,7 @@ export function MultiSelectFormItem<TSchema extends Record<string, unknown>>({
         name={field}
         render={({ field: { value, onChange } }) => (
           <MultiSelect
+            id={field}
             options={options}
             defaultValue={value}
             onValueChange={(selected) => onChange(selected)}

--- a/src/features/network/components/create-network-config-form.tsx
+++ b/src/features/network/components/create-network-config-form.tsx
@@ -18,7 +18,7 @@ type Props = {
   onSuccess: () => void
 }
 
-// All parent routes should be includes, so it's not possible to have a route collision.
+// All parent routes should be included, so it's not possible to have a route collision.
 const disallowedNetworkIds = ['settings', 'app-studio']
 
 export function CreateNetworkConfigForm({ onSuccess }: Props) {

--- a/src/features/network/components/create-network-config-form.tsx
+++ b/src/features/network/components/create-network-config-form.tsx
@@ -17,6 +17,10 @@ import { Alert } from '@/features/common/components/alert'
 type Props = {
   onSuccess: () => void
 }
+
+// All parent routes should be includes, so it's not possible to have a route collision.
+const disallowedNetworkIds = ['settings', 'app-studio']
+
 export function CreateNetworkConfigForm({ onSuccess }: Props) {
   const setCustomNetworkConfig = useSetCustomNetworkConfig()
   const networkConfigs = useNetworkConfigs()
@@ -25,6 +29,10 @@ export function CreateNetworkConfigForm({ onSuccess }: Props) {
   const createNetwork = useCallback(
     (values: z.infer<typeof createNetworkConfigFormSchema>) => {
       const networkId = generateNetworkId(values.name)
+
+      if (disallowedNetworkIds.includes(networkId)) {
+        throw new Error(`A network with id '${networkId}' matches a disallowed value, please choose a different name`)
+      }
 
       if (existingNetworkIds.includes(networkId)) {
         throw new Error(`A network with id '${networkId}' already exists, please choose a different name`)

--- a/src/features/network/components/network-configs-table.tsx
+++ b/src/features/network/components/network-configs-table.tsx
@@ -1,5 +1,5 @@
 import { ColumnDef } from '@tanstack/react-table'
-import { defaultNetworkConfigs, useDeleteCustomNetworkConfig, useNetworkConfigs } from '@/features/network/data'
+import { defaultNetworkConfigs, useDeleteCustomNetworkConfig, useNetworkConfigs, useSelectedNetwork } from '@/features/network/data'
 import { trimCharacterFromEnd } from '@/utils/trim-character-from-end'
 import { DataTable } from '@/features/common/components/data-table'
 import { Button } from '@/features/common/components/button'
@@ -11,6 +11,7 @@ import { ConfirmButton } from '@/features/common/components/confirm-button'
 import { toast } from 'react-toastify'
 import { NetworkConfigWithId } from '@/features/network/data/types'
 import { Pencil, Plus, Trash, RotateCcw } from 'lucide-react'
+import { useRefreshDataProviderToken } from '@/features/common/data'
 
 export const networkConfigsTableLabel = 'Network Configs'
 export const createNetworkConfigDialogLabel = 'Create Network'
@@ -129,6 +130,7 @@ function EditNetworkButton({ networkConfig }: ButtonProps) {
   )
 }
 
+// TODO: NC - If you delete the network you have selected, it doesn't choose a different one.
 function DeleteNetworkButton({ networkConfig }: ButtonProps) {
   const deleteNetworkConfig = useDeleteCustomNetworkConfig()
   const deleteNetwork = useCallback(() => {
@@ -156,10 +158,15 @@ type ResetNetworkButtonProps = ButtonProps & {
 
 function ResetNetworkButton({ networkConfig, settingsHaveChanged }: ResetNetworkButtonProps) {
   const deleteNetworkConfig = useDeleteCustomNetworkConfig()
+  const refreshDataProviderToken = useRefreshDataProviderToken()
+  const [selectedNetwork] = useSelectedNetwork()
   const resetNetworkToDefaults = useCallback(() => {
     deleteNetworkConfig(networkConfig.id)
     toast.success(`${networkConfig.name} has been reset`)
-  }, [deleteNetworkConfig, networkConfig])
+    if (networkConfig.id === selectedNetwork) {
+      refreshDataProviderToken()
+    }
+  }, [deleteNetworkConfig, networkConfig.id, networkConfig.name, refreshDataProviderToken, selectedNetwork])
 
   return (
     <ConfirmButton

--- a/src/features/network/components/network-configs-table.tsx
+++ b/src/features/network/components/network-configs-table.tsx
@@ -1,5 +1,11 @@
 import { ColumnDef } from '@tanstack/react-table'
-import { defaultNetworkConfigs, useDeleteCustomNetworkConfig, useNetworkConfigs, useSelectedNetwork } from '@/features/network/data'
+import {
+  defaultNetworkConfigs,
+  localnetId,
+  useDeleteCustomNetworkConfig,
+  useNetworkConfigs,
+  useSelectedNetwork,
+} from '@/features/network/data'
 import { trimCharacterFromEnd } from '@/utils/trim-character-from-end'
 import { DataTable } from '@/features/common/components/data-table'
 import { Button } from '@/features/common/components/button'
@@ -130,13 +136,17 @@ function EditNetworkButton({ networkConfig }: ButtonProps) {
   )
 }
 
-// TODO: NC - If you delete the network you have selected, it doesn't choose a different one.
 function DeleteNetworkButton({ networkConfig }: ButtonProps) {
   const deleteNetworkConfig = useDeleteCustomNetworkConfig()
+  const [selectedNetwork, setSelectedNetwork] = useSelectedNetwork()
+
   const deleteNetwork = useCallback(() => {
     deleteNetworkConfig(networkConfig.id)
     toast.success(`${networkConfig.name} has been deleted`)
-  }, [deleteNetworkConfig, networkConfig])
+    if (selectedNetwork === networkConfig.id) {
+      setSelectedNetwork(localnetId)
+    }
+  }, [deleteNetworkConfig, networkConfig.id, networkConfig.name, selectedNetwork, setSelectedNetwork])
 
   return (
     <ConfirmButton
@@ -160,6 +170,7 @@ function ResetNetworkButton({ networkConfig, settingsHaveChanged }: ResetNetwork
   const deleteNetworkConfig = useDeleteCustomNetworkConfig()
   const refreshDataProviderToken = useRefreshDataProviderToken()
   const [selectedNetwork] = useSelectedNetwork()
+
   const resetNetworkToDefaults = useCallback(() => {
     deleteNetworkConfig(networkConfig.id)
     toast.success(`${networkConfig.name} has been reset`)

--- a/src/features/network/data/index.ts
+++ b/src/features/network/data/index.ts
@@ -180,7 +180,7 @@ export const useDeleteCustomNetworkConfig = () => {
 
 const storedSelectedNetworkIdAtom = atomWithStorage('network', localnetId, undefined, { getOnInit: true })
 const selectedNetworkAtomId = atomWithRefresh((get) => {
-  const networkId = window.location.pathname.split('/')[1] // TODO: NC - Fix: If a network called 'settings' is created then things will break
+  const networkId = window.location.pathname.split('/')[1]
   const networkConfigs = get(networkConfigsAtom)
 
   if (networkId in networkConfigs) {

--- a/src/features/network/data/index.ts
+++ b/src/features/network/data/index.ts
@@ -88,25 +88,34 @@ const customNetworkConfigsAtom = atomWithStorage<Record<NetworkId, NetworkConfig
 })
 
 export const temporaryLocalNetConfigAtom = atomWithDefault<NetworkConfig | undefined>(() => {
-  const searchParams = new URLSearchParams(window.location.search)
-  const networkId = window.location.pathname.split('/')[1]
+  const url = new URL(window.location.href)
+  const networkId = url.pathname.split('/')[1]
 
   if (
     networkId === localnetId &&
-    searchParams.size > 0 &&
-    (searchParams.has(temporaryLocalNetSearchParams.algodServer) ||
-      searchParams.has(temporaryLocalNetSearchParams.algodPort) ||
-      searchParams.has(temporaryLocalNetSearchParams.indexerServer) ||
-      searchParams.has(temporaryLocalNetSearchParams.indexerPort) ||
-      searchParams.has(temporaryLocalNetSearchParams.kmdServer) ||
-      searchParams.has(temporaryLocalNetSearchParams.kmdPort))
+    url.searchParams.size > 0 &&
+    (url.searchParams.has(temporaryLocalNetSearchParams.algodServer) ||
+      url.searchParams.has(temporaryLocalNetSearchParams.algodPort) ||
+      url.searchParams.has(temporaryLocalNetSearchParams.indexerServer) ||
+      url.searchParams.has(temporaryLocalNetSearchParams.indexerPort) ||
+      url.searchParams.has(temporaryLocalNetSearchParams.kmdServer) ||
+      url.searchParams.has(temporaryLocalNetSearchParams.kmdPort))
   ) {
-    const algodServer = searchParams.get(temporaryLocalNetSearchParams.algodServer)
-    const algodPort = searchParams.get(temporaryLocalNetSearchParams.algodPort)
-    const indexerServer = searchParams.get(temporaryLocalNetSearchParams.indexerServer)
-    const indexerPort = searchParams.get(temporaryLocalNetSearchParams.indexerPort)
-    const kmdServer = searchParams.get(temporaryLocalNetSearchParams.kmdServer)
-    const kmdPort = searchParams.get(temporaryLocalNetSearchParams.kmdPort)
+    const algodServer = url.searchParams.get(temporaryLocalNetSearchParams.algodServer)
+    const algodPort = url.searchParams.get(temporaryLocalNetSearchParams.algodPort)
+    const indexerServer = url.searchParams.get(temporaryLocalNetSearchParams.indexerServer)
+    const indexerPort = url.searchParams.get(temporaryLocalNetSearchParams.indexerPort)
+    const kmdServer = url.searchParams.get(temporaryLocalNetSearchParams.kmdServer)
+    const kmdPort = url.searchParams.get(temporaryLocalNetSearchParams.kmdPort)
+
+    url.searchParams.delete(temporaryLocalNetSearchParams.algodServer)
+    url.searchParams.delete(temporaryLocalNetSearchParams.algodPort)
+    url.searchParams.delete(temporaryLocalNetSearchParams.indexerServer)
+    url.searchParams.delete(temporaryLocalNetSearchParams.indexerPort)
+    url.searchParams.delete(temporaryLocalNetSearchParams.kmdServer)
+    url.searchParams.delete(temporaryLocalNetSearchParams.kmdPort)
+
+    window.history.replaceState({}, '', url)
 
     const defaultLocalNetConfig = defaultNetworkConfigs.localnet
     return {

--- a/src/features/network/pages/network-page.tsx
+++ b/src/features/network/pages/network-page.tsx
@@ -1,7 +1,7 @@
 import { useRequiredParam } from '@/features/common/hooks/use-required-param'
 import { UrlParams } from '@/routes/urls'
-import { temporaryLocalNetSearchParams, useNetworkConfigs, useSelectedNetwork } from '@/features/network/data'
-import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
+import { useNetworkConfigs, useSelectedNetwork } from '@/features/network/data'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { useEffect } from 'react'
 
 type Props = {
@@ -11,7 +11,6 @@ type Props = {
 export function NetworkPage({ children }: Props) {
   const { networkId } = useRequiredParam(UrlParams.NetworkId)
   const networkConfigs = useNetworkConfigs()
-  const [searchParams, setSearchParams] = useSearchParams()
 
   const isWildcardNetworkRoute = networkId === '_'
   if (!(networkId in networkConfigs) && !isWildcardNetworkRoute) {
@@ -27,22 +26,6 @@ export function NetworkPage({ children }: Props) {
       navigate(pathname.replace('_', selectedNetwork) + search + hash)
     }
   }, [hash, pathname, search, navigate, selectedNetwork, isWildcardNetworkRoute])
-
-  useEffect(() => {
-    const initialParamCount = searchParams.size
-    if (initialParamCount > 0) {
-      searchParams.delete(temporaryLocalNetSearchParams.algodServer)
-      searchParams.delete(temporaryLocalNetSearchParams.algodPort)
-      searchParams.delete(temporaryLocalNetSearchParams.indexerServer)
-      searchParams.delete(temporaryLocalNetSearchParams.indexerPort)
-      searchParams.delete(temporaryLocalNetSearchParams.kmdServer)
-      searchParams.delete(temporaryLocalNetSearchParams.kmdPort)
-      if (searchParams.size < initialParamCount) {
-        setSearchParams(searchParams)
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   return children
 }

--- a/src/features/network/pages/network-page.tsx
+++ b/src/features/network/pages/network-page.tsx
@@ -1,15 +1,17 @@
 import { useRequiredParam } from '@/features/common/hooks/use-required-param'
 import { UrlParams } from '@/routes/urls'
-import { useNetworkConfigs, useSelectedNetwork } from '@/features/network/data'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { temporaryLocalNetSearchParams, useNetworkConfigs, useSelectedNetwork } from '@/features/network/data'
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import { useEffect } from 'react'
 
 type Props = {
   children: React.ReactNode
 }
+
 export function NetworkPage({ children }: Props) {
   const { networkId } = useRequiredParam(UrlParams.NetworkId)
   const networkConfigs = useNetworkConfigs()
+  const [searchParams, setSearchParams] = useSearchParams()
 
   const isWildcardNetworkRoute = networkId === '_'
   if (!(networkId in networkConfigs) && !isWildcardNetworkRoute) {
@@ -25,6 +27,22 @@ export function NetworkPage({ children }: Props) {
       navigate(pathname.replace('_', selectedNetwork) + search + hash)
     }
   }, [hash, pathname, search, navigate, selectedNetwork, isWildcardNetworkRoute])
+
+  useEffect(() => {
+    const initialParamCount = searchParams.size
+    if (initialParamCount > 0) {
+      searchParams.delete(temporaryLocalNetSearchParams.algodServer)
+      searchParams.delete(temporaryLocalNetSearchParams.algodPort)
+      searchParams.delete(temporaryLocalNetSearchParams.indexerServer)
+      searchParams.delete(temporaryLocalNetSearchParams.indexerPort)
+      searchParams.delete(temporaryLocalNetSearchParams.kmdServer)
+      searchParams.delete(temporaryLocalNetSearchParams.kmdPort)
+      if (searchParams.size < initialParamCount) {
+        setSearchParams(searchParams)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return children
 }


### PR DESCRIPTION
**Features**
- Allow temporary customisation of the localnet config using url search params. This is used when launching lora via `algokit explore localnet` inside a GitHub codespace.

**Fixes**
- Set selected network to localnet when deleting a custom network that is currently selected.
- Reset data provider when resetting the settings of a default network that has been modified and is currently selected.
- Disallow creating custom networks with the name `settings` or `app-studio`, as they collide with app routes and will cause weird behaviours.
- Add id to multiselect so the label is valid.