### PR TITLE
fix: don't limit latest transactions to the latest 10 blocks

### DIFF
--- a/src/features/explore/data/live-explorer.ts
+++ b/src/features/explore/data/live-explorer.ts
@@ -3,7 +3,7 @@ import { BlockSummary } from '@/features/blocks/models'
 import { TransactionSummary } from '@/features/transactions/models'
 import { atomEffect } from 'jotai-effect'
 import { blockResultsAtom, syncedRoundAtom } from '@/features/blocks/data'
-import { getTransactionResultAtom } from '@/features/transactions/data'
+import { getTransactionResultAtom, latestTransactionIdsAtom } from '@/features/transactions/data'
 import { asTransactionSummary } from '@/features/transactions/mappers'
 import { asBlockSummary } from '@/features/blocks/mappers'
 import { isDefined } from '@/utils/is-defined.ts'
@@ -36,7 +36,8 @@ const liveExplorerAtomsBuilder = () => {
               const block = await get(blockResult[0])
               const transactionSummaries = await Promise.all(
                 block.transactionIds.map(async (transactionId) => {
-                  const transactionResult = await get(getTransactionResultAtom(transactionId, { skipTimestampUpdate: true }))
+                  const transactionResultAtom = getTransactionResultAtom(transactionId, { skipTimestampUpdate: true })
+                  const transactionResult = await get.peek(transactionResultAtom)
                   return asTransactionSummary(transactionResult)
                 })
               )
@@ -47,18 +48,16 @@ const liveExplorerAtomsBuilder = () => {
         )
       ).filter(isDefined)
 
-      const latestTransactionSummaries: TransactionSummary[] = []
-      exit_loops: for (const block of latestBlockSummaries) {
-        const transactions = block.transactions.reverse()
-        for (const transaction of transactions) {
-          latestTransactionSummaries.push(transaction)
-          if (latestTransactionSummaries.length >= maxTransactionsToDisplay) {
-            break exit_loops
-          }
-        }
-      }
-      set(latestTransactionSummariesAtom, latestTransactionSummaries.slice(0, maxTransactionsToDisplay))
+      const latestTransactionIds = get.peek(latestTransactionIdsAtom)
+      const latestTransactionSummaries = await Promise.all(
+        latestTransactionIds.slice(0, maxTransactionsToDisplay).map(async ([transactionId]) => {
+          const transactionResultAtom = getTransactionResultAtom(transactionId, { skipTimestampUpdate: true })
+          const transactionResult = await get.peek(transactionResultAtom)
+          return asTransactionSummary(transactionResult)
+        })
+      )
 
+      set(latestTransactionSummariesAtom, latestTransactionSummaries)
       set(latestBlockSummariesAtom, latestBlockSummaries)
     })()
   })

--- a/src/features/explore/pages/explore-page.test.tsx
+++ b/src/features/explore/pages/explore-page.test.tsx
@@ -8,14 +8,14 @@ import { latestTransactionsTitle } from '@/features/transactions/components/late
 import { blockResultsAtom, syncedRoundAtom } from '@/features/blocks/data'
 import { blockResultMother } from '@/tests/object-mother/block-result'
 import { transactionResultMother } from '@/tests/object-mother/transaction-result'
-import { transactionResultsAtom } from '@/features/transactions/data'
+import { latestTransactionIdsAtom, transactionResultsAtom } from '@/features/transactions/data'
 import { BlockResult, Round } from '@/features/blocks/data/types'
 import { TransactionResult } from '@algorandfoundation/algokit-utils/types/indexer'
 import { TransactionId } from '@/features/transactions/data/types'
 import { randomNumberBetween } from '@makerx/ts-dossier'
 import { ellipseId } from '@/utils/ellipse-id'
 import { ellipseAddress } from '@/utils/ellipse-address'
-import { createAtomAndTimestamp } from '@/features/common/data'
+import { createAtomAndTimestamp, createTimestamp } from '@/features/common/data'
 
 describe('explore-page', () => {
   describe('when no blocks are available', () => {
@@ -57,6 +57,10 @@ describe('explore-page', () => {
     const myStore = createStore()
     myStore.set(blockResultsAtom, new Map([[block.round, createAtomAndTimestamp(block)]]))
     myStore.set(transactionResultsAtom, new Map(transactionResults.map((x) => [x.id, createAtomAndTimestamp(x)])))
+    myStore.set(
+      latestTransactionIdsAtom,
+      transactionResults.map((t) => [t.id, createTimestamp()] as const)
+    )
     myStore.set(syncedRoundAtom, block.round)
 
     it('the processed blocks are displayed', () => {
@@ -142,8 +146,12 @@ describe('explore-page', () => {
       )
     })
 
-    it('the latest 10 transactions are displayed', () => {
+    it('the latest 8 transactions are displayed', () => {
       const myStore = createStore()
+      myStore.set(
+        latestTransactionIdsAtom,
+        Array.from(data.transactions.entries()).map(([id, _]) => [id, createTimestamp()] as const)
+      )
       myStore.set(transactionResultsAtom, data.transactions)
       myStore.set(blockResultsAtom, data.blocks)
       myStore.set(syncedRoundAtom, data.syncedRound)

--- a/src/features/explore/pages/explore-page.tsx
+++ b/src/features/explore/pages/explore-page.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/features/common/utils'
 import { LatestTransactions } from '@/features/transactions/components/latest-transactions'
 import { Switch } from '@/features/common/components/switch'
 import { Label } from '@/features/common/components/label'
-import { useLiveExplorer } from '@/features/explore/data/live-explorer.ts'
+import { useLiveExplorer } from '@/features/explore/data/live-explorer'
 
 export const explorePageTitle = 'Explore'
 


### PR DESCRIPTION
Fixes https://github.com/algorandfoundation/algokit-lora/issues/164

The below shows the behaviour before (right) and after (left). Wait until the end.
![latest-transactions](https://github.com/user-attachments/assets/85b1801b-48f5-4511-a35c-4aec898d7044)
