### PR TITLE
chore: adjust history when changing networks

### DIFF
--- a/src/features/network/pages/network-page.tsx
+++ b/src/features/network/pages/network-page.tsx
@@ -1,5 +1,5 @@
 import { useRequiredParam } from '@/features/common/hooks/use-required-param'
-import { UrlParams } from '@/routes/urls'
+import { UrlParams, Urls } from '@/routes/urls'
 import { useNetworkConfigs, useSelectedNetwork } from '@/features/network/data'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useEffect } from 'react'
@@ -8,12 +8,13 @@ type Props = {
   children: React.ReactNode
 }
 
+const wildcardNetworkRoute = '_'
+
 export function NetworkPage({ children }: Props) {
   const { networkId } = useRequiredParam(UrlParams.NetworkId)
   const networkConfigs = useNetworkConfigs()
 
-  const isWildcardNetworkRoute = networkId === '_'
-  if (!(networkId in networkConfigs) && !isWildcardNetworkRoute) {
+  if (!(networkId in networkConfigs) && networkId !== wildcardNetworkRoute) {
     throw new Error(`"${networkId}" is not a valid network.`)
   }
 
@@ -22,10 +23,16 @@ export function NetworkPage({ children }: Props) {
   const { pathname, search, hash } = useLocation()
 
   useEffect(() => {
-    if (isWildcardNetworkRoute) {
-      navigate(pathname.replace('_', selectedNetwork) + search + hash)
+    if (networkId === wildcardNetworkRoute) {
+      // Handle the wildcard network route
+      navigate(pathname.replace(wildcardNetworkRoute, selectedNetwork) + search + hash, { replace: true })
+    } else if (networkId !== selectedNetwork) {
+      // When a user changes the network, their history will contain routes for the previous network.
+      // This handles navigating the user to the explore page for the selected network, so they don't get 404s when navigating through history.
+      navigate(Urls.Explore.build({ networkId: selectedNetwork }), { replace: true })
     }
-  }, [hash, pathname, search, navigate, selectedNetwork, isWildcardNetworkRoute])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [networkId, selectedNetwork])
 
   return children
 }


### PR DESCRIPTION
Resolves https://github.com/algorandfoundation/algokit-lora/issues/166

When changing networks, the browser history will still contain explore routes from the previous network selection.
These explore routes will likely result in 404s, as the id's don't apply to the active network.
Instead of 404'ing, navigate (and replace the route in history) to the explore page for the active network.