### PR TITLE
bug: handle create application transactions received from algod

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,7 +1,2 @@
 {
-  "1098615": {
-    "active": true,
-    "notes": "Ignored because there is no fix yet",
-    "expiry": "2024-10-01"
-  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9207,11 +9207,11 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/src/features/abi-methods/data/abi-method.test.tsx
+++ b/src/features/abi-methods/data/abi-method.test.tsx
@@ -15,6 +15,7 @@ import { groupResultMother } from '@/tests/object-mother/group-result'
 import { groupResultsAtom } from '@/features/groups/data'
 import { AppInterfaceEntity } from '@/features/common/data/indexed-db'
 import { atom } from 'jotai/index'
+import { genesisHashAtom } from '@/features/blocks/data'
 
 const { myStore } = await vi.hoisted(async () => {
   const { getDefaultStore } = await import('jotai/index')
@@ -416,6 +417,18 @@ describe('resolving ABI method', () => {
           ],
         },
       ])
+    })
+  })
+
+  describe('for an create application transaction from algod', () => {
+    const transaction = transactionResultMother['localnet-AV37TJVLBWXPI3EAUJJSDTAIQX22ECPMVADIOCR47TTRCPVPRG3Q']().build()
+
+    it('should return undefined abiMethod', async () => {
+      myStore.set(transactionResultsAtom, new Map([[transaction.id, createReadOnlyAtomAndTimestamp(transaction)]]))
+      myStore.set(genesisHashAtom, 'some-hash')
+
+      const abiMethod = await myStore.get(abiMethodResolver(transaction))
+      expect(abiMethod).toBeUndefined()
     })
   })
 })

--- a/src/features/abi-methods/data/abi-method.test.tsx
+++ b/src/features/abi-methods/data/abi-method.test.tsx
@@ -420,10 +420,10 @@ describe('resolving ABI method', () => {
     })
   })
 
-  describe('for an create application transaction from algod', () => {
+  describe('for an create application transaction received from algod', () => {
     const transaction = transactionResultMother['localnet-AV37TJVLBWXPI3EAUJJSDTAIQX22ECPMVADIOCR47TTRCPVPRG3Q']().build()
 
-    it('should return undefined abiMethod', async () => {
+    it('abiMethod should be undefined', async () => {
       myStore.set(transactionResultsAtom, new Map([[transaction.id, createReadOnlyAtomAndTimestamp(transaction)]]))
       myStore.set(genesisHashAtom, 'some-hash')
 

--- a/src/features/abi-methods/data/abi-method.ts
+++ b/src/features/abi-methods/data/abi-method.ts
@@ -190,7 +190,8 @@ const isPossibleAbiAppCallTransaction = (transaction: TransactionResult): boolea
     transaction['tx-type'] === TransactionType.appl &&
     transaction['application-transaction'] !== undefined &&
     transaction['confirmed-round'] !== undefined &&
-    transaction['application-transaction']?.['application-args'] !== undefined &&
+    Boolean(transaction['application-transaction']['application-id']) &&
+    transaction['application-transaction']['application-args'] !== undefined &&
     transaction['application-transaction']['application-args'].length > 0 &&
     base64ToBytes(transaction['application-transaction']['application-args'][0]).length === 4
   )

--- a/src/features/search/components/search.test.tsx
+++ b/src/features/search/components/search.test.tsx
@@ -79,14 +79,17 @@ describe('search', () => {
         return executeComponentTest(
           () => render(<Search />, undefined, myStore),
           async (component, user) => {
-            await waitFor(async () => {
-              const input = component.getByPlaceholderText(searchPlaceholderLabel)
-              await user.type(input, id)
-              const results = (await component.findAllByText(label, undefined, { timeout: 1000 })).map((result) => result.parentElement)
-              const result = results.find((result) => result!.textContent!.includes(type))!
-              await user.click(result)
-              expect(mockNavigate).toHaveBeenCalledWith(`/localnet/${type.toLowerCase()}/${id}`)
-            })
+            await waitFor(
+              async () => {
+                const input = component.getByPlaceholderText(searchPlaceholderLabel)
+                await user.type(input, id)
+                const results = (await component.findAllByText(label, undefined, { timeout: 1000 })).map((result) => result.parentElement)
+                const result = results.find((result) => result!.textContent!.includes(type))!
+                await user.click(result)
+                expect(mockNavigate).toHaveBeenCalledWith(`/localnet/${type.toLowerCase()}/${id}`)
+              },
+              { timeout: 10000 }
+            )
           }
         )
       })

--- a/src/tests/object-mother/transaction-result.ts
+++ b/src/tests/object-mother/transaction-result.ts
@@ -3380,4 +3380,74 @@ export const transactionResultMother = {
       'tx-type': 'appl',
     } as unknown as TransactionResult)
   },
+  'localnet-AV37TJVLBWXPI3EAUJJSDTAIQX22ECPMVADIOCR47TTRCPVPRG3Q': () => {
+    return new TransactionResultBuilder({
+      id: 'AV37TJVLBWXPI3EAUJJSDTAIQX22ECPMVADIOCR47TTRCPVPRG3Q',
+      'application-transaction': {
+        // algod returns undefined for application-id when creating an application
+        'application-id': undefined,
+        'approval-program':
+          'CiADAAEEJgYLYXVjdGlvbl9lbmQMcHJldmlvdXNfYmlkD3ByZXZpb3VzX2JpZGRlcgNhc2EKYXNhX2Ftb3VudAVjbGFpbTEYQAADiAGjMRtBAKaABCgmsgKABPCqcCOABDDG1YqABNt/6EOABOZUYluABB7BK+82GgCOBgABABMAMQA9AFMAXwAxGRREMRhENhoBF8AwiABqI0MxGRREMRhENhoBFzYaAhcxFiMJSTgQJBJEiABwI0MxGRREMRhEiACQI0MxGRREMRhEMRYjCUk4ECMSRIgAfiNDMRkURDEYRIgAoiNDMRkURDEYRDYaARfAMIgAzyNDMRkURDEYFEQjQ4oBADEAMgkSRCIrZUQURCuL/2exMgqL/7IRshQkshAisgGziYoDADEAMgkSRCIoZUQURIv/OBQyChJEi/84EicETGcyB4v+CChMZymL/WeJigAAiYoBADIHIihlRAxEi/84AEkxABJEi/84CCIpZURLAQxEKUsBZypPAmcxACcFTwJmiYoAADEAIicFY0xJTwJEMQAiKmVEEkEACiIpZUSLAEwJjAGxMQCyB4sBSbIII7IQIrIBszEAiwBPAgknBUxmiYoBADIHIihlRA1EsSIqZUQiKmVEIicEZUSyErIUshWL/7IRJLIQIrIBs4mKAAAoImcpImcnBCJnKyJnKjIDZ4k=',
+        'clear-state-program': 'CoEBQw==',
+        'on-completion': 'noop',
+        'global-state-schema': {
+          'num-byte-slice': 1,
+          'num-uint': 4,
+        },
+        'local-state-schema': {
+          'num-uint': 1,
+        },
+        'application-args': ['K5iklw=='],
+      },
+      'first-valid': 1,
+      'last-valid': 1001,
+      'tx-type': 'appl',
+      fee: 1000,
+      sender: 'YKPOB2GX4UVLSNNHJQQUPQ7G3VB6XN4HC7N5HMGAN2N4XZ45AXRTJ5HRUA',
+      'confirmed-round': 2,
+      'round-time': 1724804397,
+      'intra-round-offset': 0,
+      'genesis-hash': 'OFOY5kr3N/IpXmQ3RPI/pfJjbdGhOVO2t5YHtC4npZ0=',
+      'genesis-id': 'dockernet-v1',
+      note: 'QUxHT0tJVF9ERVBMT1lFUjpqeyJuYW1lIjogIkF1Y3Rpb24iLCAidmVyc2lvbiI6ICJ2MS4wIiwgImRlbGV0YWJsZSI6IG51bGwsICJ1cGRhdGFibGUiOiBudWxsfQ==',
+      lease: '',
+      'created-application-index': 1002,
+      signature: {
+        sig: 'SWcc0w0p5fzxcx/Dd5PLEQuTQ4tsS97Li5TlusVaQlJIGzRH0qjojFpCEsVMAw98EejGokiH3ZPTdNjQSO5tDw==',
+      },
+      'global-state-delta': [
+        {
+          key: 'YXNh',
+          value: {
+            action: 2,
+          },
+        },
+        {
+          key: 'YXNhX2Ftb3VudA==',
+          value: {
+            action: 2,
+          },
+        },
+        {
+          key: 'YXVjdGlvbl9lbmQ=',
+          value: {
+            action: 2,
+          },
+        },
+        {
+          key: 'cHJldmlvdXNfYmlk',
+          value: {
+            action: 2,
+          },
+        },
+        {
+          key: 'cHJldmlvdXNfYmlkZGVy',
+          value: {
+            action: 1,
+            bytes: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+          },
+        },
+      ],
+    } as unknown as TransactionResult)
+  },
 }


### PR DESCRIPTION
For create app transactions, algod return undefined for `application-id` field. This caused an issue with the logic to fetch app spec from indexed db. 