### PR TITLE
Transaction visualiser amount rounding #238

### DIFF
--- a/src/features/transactions-graph/components/__snapshots__/application-transaction-graph.INDQXWQXHF22SO45EZY7V6FFNI6WUD5FHRVDV6NCU6HD424BJGGA.html
+++ b/src/features/transactions-graph/components/__snapshots__/application-transaction-graph.INDQXWQXHF22SO45EZY7V6FFNI6WUD5FHRVDV6NCU6HD424BJGGA.html
@@ -932,7 +932,7 @@
             <div
               class="gap-0.5 flex justify-center"
             >
-              ≈2.8
+              2.770045
               <svg
                 class="h-auto w-2.5"
                 height="1em"
@@ -1138,7 +1138,7 @@
                 class="flex items-center gap-1"
               >
                 <span>
-                  ≈0.59
+                  0.586582
                 </span>
                 <a
                   class="underline text-asset-transfer"
@@ -1242,7 +1242,7 @@
                 class="flex items-center gap-1"
               >
                 <span>
-                  ≈0.59
+                  0.586582
                 </span>
                 <a
                   class="underline text-asset-transfer"

--- a/src/features/transactions-graph/components/__snapshots__/application-transaction-graph.WYEGSIGWZHTR6VYXC3EXFGZQHYKI6FQOZU2DOKHQCAWYEIHJBKEA.html
+++ b/src/features/transactions-graph/components/__snapshots__/application-transaction-graph.WYEGSIGWZHTR6VYXC3EXFGZQHYKI6FQOZU2DOKHQCAWYEIHJBKEA.html
@@ -934,7 +934,7 @@
                 class="flex items-center gap-1"
               >
                 <span>
-                  ≈1
+                  1.048576
                 </span>
                 <a
                   class="underline text-asset-transfer"
@@ -1111,7 +1111,7 @@
             <div
               class="gap-0.5 flex justify-center"
             >
-              ≈0.73
+              0.732252
               <svg
                 class="h-auto w-2.5"
                 height="1em"

--- a/src/features/transactions-graph/components/__snapshots__/group-graph.%2FoRSr2uMFemQhwQliJO18b64Nl1QIkjA39ZszRCeSCI%3D.html
+++ b/src/features/transactions-graph/components/__snapshots__/group-graph.%2FoRSr2uMFemQhwQliJO18b64Nl1QIkjA39ZszRCeSCI%3D.html
@@ -932,7 +932,7 @@
             <div
               class="gap-0.5 flex justify-center"
             >
-              ≈2.8
+              2.770045
               <svg
                 class="h-auto w-2.5"
                 height="1em"
@@ -1138,7 +1138,7 @@
                 class="flex items-center gap-1"
               >
                 <span>
-                  ≈0.59
+                  0.586582
                 </span>
                 <a
                   class="underline text-asset-transfer"
@@ -1242,7 +1242,7 @@
                 class="flex items-center gap-1"
               >
                 <span>
-                  ≈0.59
+                  0.586582
                 </span>
                 <a
                   class="underline text-asset-transfer"

--- a/src/utils/compact-amount.ts
+++ b/src/utils/compact-amount.ts
@@ -1,7 +1,7 @@
 import Decimal from 'decimal.js'
 
 export const compactAmount = (amount: Decimal | number) => {
-  if (amount.toString().length < 8) {
+  if (amount.toString().length < 9) {
     return amount.toString()
   }
 


### PR DESCRIPTION
I have changed the line in [https://github.com/algorandfoundation/algokit-lora/blob/main/src/utils/compact-amount.ts#L4](url) from 8 to 9 for echancement #238 .

First i have tested out the scenario by making a transaction [http://localhost:1420/testnet/transaction/HZXSLRMSVSHXYH3VILN62EFLZD6Y3XNOQPDTJ2QGJV73IJLI3U4Q](url) as which was discussed in discord [https://discord.com/channels/491256308461207573/1277185471214256138](url) and got below visual image which looks good & all 6 digits are visible.

**Previous Snapshot -**
![transactions-visual (8)](https://github.com/user-attachments/assets/3deade59-eb06-4866-9461-8cb20de0c81e)
**Updated Snapshot -**
![transaction-HZXSLRMSVSHXYH3VILN62EFLZD6Y3XNOQPDTJ2QGJV73IJLI3U4Q](https://github.com/user-attachments/assets/8c9ae176-8053-4398-a8da-34b4d22ee81d)



I have ran the tests & got 3 errors in the following transactions due to snapshot mismatch

1. [http://localhost:1420/mainnet/transaction/WYEGSIGWZHTR6VYXC3EXFGZQHYKI6FQOZU2DOKHQCAWYEIHJBKEA](url) - 

**Previous Snapshot -**
![transactions-visual (5)](https://github.com/user-attachments/assets/6100dd72-cdb4-4f79-bc77-f6a225e6f7e7)
**Updated Snapshot -**
![transaction-WYEGSIGWZHTR6VYXC3EXFGZQHYKI6FQOZU2DOKHQCAWYEIHJBKEA](https://github.com/user-attachments/assets/396d5387-3a68-4f3f-a926-f81dfa830db4)

2. [http://localhost:1420/mainnet/transaction/INDQXWQXHF22SO45EZY7V6FFNI6WUD5FHRVDV6NCU6HD424BJGGA](url) - 

**Previous Snapshot -**
![transactions-visual (6)](https://github.com/user-attachments/assets/a7982586-64a2-44a0-ae7a-529a605b5ea7)
**Updated Snapshot -**
![transaction-INDQXWQXHF22SO45EZY7V6FFNI6WUD5FHRVDV6NCU6HD424BJGGA](https://github.com/user-attachments/assets/21b4acfd-47db-44a1-ad0b-16b04b7e7fe3)

3. [http://localhost:1420/mainnet/block/36591812/group/%2FoRSr2uMFemQhwQliJO18b64Nl1QIkjA39ZszRCeSCI%3D](url) -

**Previous Snapshot -**
![transactions-visual (7)](https://github.com/user-attachments/assets/edfae7a5-b87e-4a67-9873-315088175ef5)
**Updated Snapshot -**
![round-36591812-group-_oRSr2uMFemQhwQliJO18b64Nl1QIkjA39ZszRCeSCI=](https://github.com/user-attachments/assets/230b24fd-da20-4955-9d84-27acb1df8d40)

I have reviewed the above 3 updated snapshots and they are visually looking good & showing upto 6 decimals. So i have updated the snapshots.

But even after updating the code, we are unable to show 6 decimals if the whole number is greater than 9, as you can see the in below scenario i have made payment transaction of amount 12.000115 algos and visual image is not showing 6 decimals.
[http://localhost:1420/testnet/transaction/ZZGHI5HFGRXCSNGY5RMPZHIAJF5G5E5NJXLQ7T6OAIIU6XBKOREQ](url)

![image](https://github.com/user-attachments/assets/cb19c3cd-e900-416d-aef9-c9cb5c0fb6b2)
