### PR TITLE
fix: use created app id in transaction summary, when creating an app

### DIFF
--- a/src/features/transactions/mappers/transaction-summary-mappers.ts
+++ b/src/features/transactions/mappers/transaction-summary-mappers.ts
@@ -29,10 +29,13 @@ export const asTransactionSummary = (transactionResult: TransactionResult): Tran
     }
     case algosdk.TransactionType.appl: {
       invariant(transactionResult['application-transaction'], 'application-transaction is not set')
+
       return {
         ...common,
         type: TransactionType.AppCall,
-        to: transactionResult['application-transaction']['application-id'],
+        to: transactionResult['application-transaction']['application-id']
+          ? transactionResult['application-transaction']['application-id']
+          : transactionResult['created-application-index']!,
         innerTransactions: transactionResult['inner-txns']?.map((t) => asTransactionSummary(t)),
       }
     }


### PR DESCRIPTION
When creating an app, the latest transactions component was showing the "to" as 0