### PR TITLE
chore: update id of cross-spawn audit ignore

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,5 +1,5 @@
 {
-  "1100467": {
+  "1100556": {
     "active": true,
     "notes": "Waiting for https://github.com/npm/cli/issues/7902 to be resolved",
     "expiry": "2024-12-31"


### PR DESCRIPTION
The id of the cross-spawn audit ignore has changed, this PR updates it.