### PR TITLE
chore: update claw icon source

### DIFF
--- a/src/assets/icons/claw.svg
+++ b/src/assets/icons/claw.svg
@@ -1,4 +1,4 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-paw-print" xmlns="http://www.w3.org/2000/svg">
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
   <defs></defs>
   <circle cx="11" cy="4" r="2"></circle>
   <circle cx="18" cy="8" r="2"></circle>


### PR DESCRIPTION
We removed the css classes from the claw react component, however the source svg wasn't updated.