### PR TITLE
Feature/search result nav link

### DIFF
--- a/src/features/search/components/search.test.tsx
+++ b/src/features/search/components/search.test.tsx
@@ -86,19 +86,19 @@ describe('search', () => {
         return executeComponentTest(
           () => render(<Search />, undefined, myStore),
           async (component, user) => {
-            const input = component.getByPlaceholderText(searchPlaceholderLabel)
-            await user.type(input, id)
-            const results = (await component.findAllByText(label, undefined, { timeout: 1000 })).map((result) => result.parentElement)
-            results.forEach((result) => {
-              const link = result!.querySelector('a')
-              const linkText = link?.textContent || ''
-              expect(linkText.substring(0, 3)).toBe(id.substring(0, 3))
-            })
-            const result = results.find((result) => result!.textContent!.includes(type))!
-            await user.click(result)
-
             await waitFor(
               async () => {
+                const input = component.getByPlaceholderText(searchPlaceholderLabel)
+                await user.type(input, id)
+
+                const results = (await component.findAllByText(label, undefined, { timeout: 1000 })).map((result) => result.parentElement)
+                results.forEach((result) => {
+                  const link = result!.querySelector('a')
+                  expect(link).toHaveTextContent(label)
+                })
+
+                const result = results.find((result) => result!.textContent!.includes(type))!
+                await user.click(result)
                 expect(mockNavigate).toHaveBeenCalledWith(`/localnet/${type.toLowerCase()}/${id}`)
               },
               { timeout: 10000 }

--- a/src/features/search/components/search.test.tsx
+++ b/src/features/search/components/search.test.tsx
@@ -89,6 +89,11 @@ describe('search', () => {
             const input = component.getByPlaceholderText(searchPlaceholderLabel)
             await user.type(input, id)
             const results = (await component.findAllByText(label, undefined, { timeout: 1000 })).map((result) => result.parentElement)
+            results.forEach((result) => {
+              const link = result!.querySelector('a')
+              const linkText = link?.textContent || ''
+              expect(linkText.substring(0, 3)).toBe(id.substring(0, 3))
+            })
             const result = results.find((result) => result!.textContent!.includes(type))!
             await user.click(result)
 

--- a/src/features/search/components/search.tsx
+++ b/src/features/search/components/search.tsx
@@ -10,7 +10,7 @@ import {
 import { cn } from '@/features/common/utils'
 import { useCallback, useEffect, useRef } from 'react'
 import { RenderLoadable } from '@/features/common/components/render-loadable'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, NavLink } from 'react-router-dom'
 import { useSearch } from '../data'
 import { Loader2 as Loader } from 'lucide-react'
 import { useLocationChange } from '@/features/common/hooks/use-location-change'
@@ -93,7 +93,9 @@ export function Search() {
                   {results.map((result) => {
                     return (
                       <CommandItem key={`${result.type}-${result.id}`} value={result.url} onSelect={handleSelection}>
-                        <span>{result.label}</span>
+                        <NavLink className="truncate text-primary underline" to={result.url}>
+                          {result.label}
+                        </NavLink>
                         <span className={cn('ml-auto text-xs')}>{result.type}</span>
                       </CommandItem>
                     )


### PR DESCRIPTION
Closes: AK-45

Commit 1: Adds NavLink around the results and use the `result.url` for href.
Commit 2: Fixed that annoying act warning for the `search.test.tsx` file

<img width="1258" alt="image" src="https://github.com/user-attachments/assets/acfb16f4-ec44-4522-b155-ec21ac9db8d7" />
