### PR TITLE
feat: update subscriber which enables block reward synthetic transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@algorandfoundation/algokit-subscriber": "^3.0.2",
+        "@algorandfoundation/algokit-subscriber": "^3.1.0",
         "@algorandfoundation/algokit-utils": "^8.1.0",
         "@auth0/auth0-react": "^2.2.4",
         "@blockshake/defly-connect": "^1.2.1",
@@ -167,9 +167,9 @@
       "license": "MIT"
     },
     "node_modules/@algorandfoundation/algokit-subscriber": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-subscriber/-/algokit-subscriber-3.0.2.tgz",
-      "integrity": "sha512-mJN+r6CtAamk2f7zh037/gmktJJa7Ox2cunq//6agDNZEVv3X4q73jDLv9RRnNva93VYjDPSyJM+WUHkWx1W3Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-subscriber/-/algokit-subscriber-3.1.0.tgz",
+      "integrity": "sha512-0iXrhJolGbZxMhtDBI145hKKGSIKjWkp/OWkQGMd2EEJPJFtKnHwpRI/tUQlgCfiDPJ65P3KiPjD7IpFCDrrKA==",
       "dependencies": {
         "js-sha512": "^0.9.0"
       },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
-    "@algorandfoundation/algokit-subscriber": "^3.0.2",
+    "@algorandfoundation/algokit-subscriber": "^3.1.0",
     "@algorandfoundation/algokit-utils": "^8.1.0",
     "@auth0/auth0-react": "^2.2.4",
     "@blockshake/defly-connect": "^1.2.1",


### PR DESCRIPTION
Updating the subscriber-ts version, so that blocks reward synthetic pay transactions (added in https://github.com/algorandfoundation/algokit-subscriber-ts/pull/110) are surfaced.