### PR TITLE
chore: move wasm test to the block mapping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5680,9 +5680,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001680",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001680.tgz",
-      "integrity": "sha512-rPQy70G6AGUMnbwS1z6Xg+RkHYPAi18ihs47GH0jcxIG7wArmPgY3XbS2sRdBbxJljp3thdT8BIqv9ccCypiPA==",
+      "version": "1.0.30001712",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001712.tgz",
+      "integrity": "sha512-MBqPpGYYdQ7/hfKiet9SCI+nmN5/hp4ZzveOJubl5DTAMa5oggjAuoi0Z4onBpKPFI2ePGnQuQIzF3VxDjDJig==",
       "dev": true,
       "funding": [
         {
@@ -17480,9 +17480,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.15",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.15.tgz",
-      "integrity": "sha512-6ANcZRivqL/4WtwPGTKNaosuNJr5tWiftOC7liM7G9+rMb8+oeJeyzymDu4rTN93seySBmbjSfsS3Vzr19KNtA==",
+      "version": "5.4.17",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.17.tgz",
+      "integrity": "sha512-5+VqZryDj4wgCs55o9Lp+p8GE78TLVg0lasCH5xFZ4jacZjtqZa6JUw9/p0WeAojaOfncSM6v77InkFPGnvPvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/features/blocks/data/block-result.ts
+++ b/src/features/blocks/data/block-result.ts
@@ -121,7 +121,7 @@ export const addStateExtractedFromBlocksAtom = atom(
               transactionResult.paymentTransaction = {
                 amount: wasmTxn.payFields!.amount,
                 receiver: wasmTxn.payFields!.receiver.address,
-                closeAmount: transactionResult.paymentTransaction.closeAmount, // This appears to be missing from the wasmTxn model
+                closeAmount: transactionResult.paymentTransaction.closeAmount,
                 closeRemainderTo: wasmTxn.payFields!.closeRemainderTo?.address,
               }
             }

--- a/src/features/blocks/data/block-result.ts
+++ b/src/features/blocks/data/block-result.ts
@@ -9,6 +9,8 @@ import { indexer } from '@/features/common/data/algo-client'
 import { TransactionResult } from '@/features/transactions/data/types'
 import { uint8ArrayToBase64 } from '@/utils/uint8-array-to-base64'
 import { indexerTransactionToTransactionResult } from '@/features/transactions/mappers/indexer-transaction-mappers'
+import { addressFromString, decodeTransaction, encodeTransaction, Transaction } from '@joe-p/algo_models'
+import { Address } from 'algosdk'
 
 export const getBlockAndExtractData = async (round: Round) => {
   // We  use indexer instead of algod, as algod might not have the full history of blocks
@@ -79,6 +81,51 @@ export const addStateExtractedFromBlocksAtom = atom(
         const next = new Map(prev)
         transactionResultsToAdd.forEach((transactionResult) => {
           if (transactionResult.id && !next.has(transactionResult.id)) {
+            // This code has been added to test the WASM encoding/decoding of payment transactions
+            if (transactionResult.txType === 'pay' && transactionResult.paymentTransaction) {
+              const txnModel: Transaction = {
+                header: {
+                  sender: addressFromString(transactionResult.sender),
+                  transactionType: 'Payment',
+                  fee: transactionResult.fee,
+                  firstValid: transactionResult.firstValid,
+                  lastValid: transactionResult.lastValid,
+                  genesisHash: transactionResult.genesisHash,
+                  genesisId: transactionResult.genesisId,
+                  note: transactionResult.note,
+                  rekeyTo: transactionResult.rekeyTo ? addressFromString(transactionResult.rekeyTo.toString()) : undefined,
+                  lease: transactionResult.lease,
+                  group: transactionResult.group,
+                },
+                payFields: {
+                  amount: transactionResult.paymentTransaction.amount,
+                  receiver: addressFromString(transactionResult.paymentTransaction.receiver),
+                  closeRemainderTo: transactionResult.paymentTransaction.closeRemainderTo
+                    ? addressFromString(transactionResult.paymentTransaction.closeRemainderTo)
+                    : undefined,
+                },
+              }
+
+              const wasmTxn = decodeTransaction(encodeTransaction(txnModel))
+
+              transactionResult.sender = wasmTxn.header.sender.address
+              transactionResult.fee = wasmTxn.header.fee
+              transactionResult.firstValid = wasmTxn.header.firstValid
+              transactionResult.lastValid = wasmTxn.header.lastValid
+              transactionResult.genesisHash = wasmTxn.header.genesisHash
+              transactionResult.genesisId = wasmTxn.header.genesisId
+              transactionResult.note = wasmTxn.header.note
+              transactionResult.rekeyTo = wasmTxn.header.rekeyTo?.address ? Address.fromString(wasmTxn.header.rekeyTo.address) : undefined
+              transactionResult.lease = wasmTxn.header.lease
+              transactionResult.group = wasmTxn.header.group
+              transactionResult.paymentTransaction = {
+                amount: wasmTxn.payFields!.amount,
+                receiver: wasmTxn.payFields!.receiver.address,
+                closeAmount: transactionResult.paymentTransaction.closeAmount, // This appears to be missing from the wasmTxn model
+                closeRemainderTo: wasmTxn.payFields!.closeRemainderTo?.address,
+              }
+            }
+
             next.set(transactionResult.id, createReadOnlyAtomAndTimestamp(transactionResult))
           }
         })

--- a/src/features/transactions/components/payment-transaction-info.tsx
+++ b/src/features/transactions/components/payment-transaction-info.tsx
@@ -6,7 +6,6 @@ import { DescriptionList } from '@/features/common/components/description-list'
 import { AccountLink } from '@/features/accounts/components/account-link'
 import { transactionAmountLabel } from './transactions-table-columns'
 import { transactionReceiverLabel, transactionSenderLabel } from './labels'
-import {addressFromString, decodeTransaction, encodeTransaction, Transaction} from '@joe-p/algo_models'
 
 type Props = {
   transaction: PaymentTransaction | InnerPaymentTransaction
@@ -16,46 +15,29 @@ export const transactionCloseRemainderToLabel = 'Close Remainder To'
 export const transactionCloseRemainderAmountLabel = 'Close Remainder Amount'
 
 export function PaymentTransactionInfo({ transaction }: Props) {
-  const txnModel: Transaction = {
-    header: {
-      sender: addressFromString(transaction.sender),
-      transactionType: 'Payment',
-      fee: transaction.fee.microAlgos,
-      firstValid: transaction.confirmedRound,
-      lastValid: transaction.confirmedRound,
-    },
-    payFields: {
-      amount: transaction.amount.microAlgos,
-      receiver: addressFromString(transaction.receiver)
-    }
-  }
-
-  const wasmTxn = decodeTransaction(encodeTransaction(txnModel));
-  console.log('Pay fields from WASM:', wasmTxn.payFields);
-
   const paymentTransactionItems = useMemo(
     () => [
       {
         dt: transactionSenderLabel,
-        dd: <AccountLink address={wasmTxn.header.sender.address} showCopyButton={true} />,
+        dd: <AccountLink address={transaction.sender} showCopyButton={true} />,
       },
       {
         dt: transactionReceiverLabel,
-        dd: <AccountLink address={wasmTxn.payFields!.receiver.address} showCopyButton={true} />,
+        dd: <AccountLink address={transaction.receiver} showCopyButton={true} />,
       },
       {
         dt: transactionAmountLabel,
-        dd: <DisplayAlgo amount={wasmTxn.payFields!.amount.microAlgo()} />,
+        dd: <DisplayAlgo amount={transaction.amount} />,
       },
-      ...(wasmTxn.payFields!.closeRemainderTo
+      ...(transaction.closeRemainder
         ? [
             {
               dt: transactionCloseRemainderToLabel,
-              dd: <AccountLink address={wasmTxn.payFields!.closeRemainderTo!.address} showCopyButton={true} />,
+              dd: <AccountLink address={transaction.closeRemainder.to} showCopyButton={true} />,
             },
             {
               dt: transactionCloseRemainderAmountLabel,
-              dd: <DisplayAlgo amount={transaction.closeRemainder!.amount} />,
+              dd: <DisplayAlgo amount={transaction.closeRemainder.amount} />,
             },
           ]
         : []),


### PR DESCRIPTION
Moving here means that the mapping is run as part of deconstructing the block that is fetched in the background.
This should help surface any issues quicker.

I also noticed that `closeAmount` doesn't appear to be available in the model.