### PR TITLE
feat: adjust how we visually represent transactions from rekeyed accounts

### DIFF
--- a/src/features/transaction-wizard/components/key-registration-transaction-builder.tsx
+++ b/src/features/transaction-wizard/components/key-registration-transaction-builder.tsx
@@ -69,7 +69,6 @@ export const keyRegistrationFormSchema = z
           path: ['voteLastValid'],
         })
       }
-      // TODO: NC - Add validation to ensure first is less than last
       if (!schema.voteKeyDilution) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,

--- a/src/features/transactions-graph/components/__snapshots__/application-transaction-graph.INDQXWQXHF22SO45EZY7V6FFNI6WUD5FHRVDV6NCU6HD424BJGGA.html
+++ b/src/features/transactions-graph/components/__snapshots__/application-transaction-graph.INDQXWQXHF22SO45EZY7V6FFNI6WUD5FHRVDV6NCU6HD424BJGGA.html
@@ -853,20 +853,42 @@
           />
         </div>
       </div>
-      <div />
       <div
         class="flex items-center justify-center z-10 relative text-payment"
         data-state="closed"
-        style="grid-column-start: 3; grid-column-end: 5;"
+        style="grid-column-start: 2; grid-column-end: 5;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-payment bg-card"
         >
-          1
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
         <div
           class="relative"
-          style="width: calc(50.00% - 20px); height: 20px;"
+          style="width: calc(66.67% - 20px); height: 20px;"
         >
           <div
             class="border-payment"
@@ -970,20 +992,42 @@
           />
         </div>
       </div>
-      <div />
       <div
         class="flex items-center justify-center z-10 relative text-application-call"
         data-state="closed"
-        style="grid-column-start: 3; grid-column-end: 6;"
+        style="grid-column-start: 2; grid-column-end: 6;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-application-call bg-card"
         >
-          1
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
         <div
           class="relative"
-          style="width: calc(66.67% - 20px); height: 20px;"
+          style="width: calc(75.00% - 20px); height: 20px;"
         >
           <div
             class="border-application-call"
@@ -1058,7 +1102,7 @@
       <div
         class="flex items-center justify-center z-10 relative text-asset-transfer"
         data-state="closed"
-        style="grid-column-start: 2; grid-column-end: 6;"
+        style="grid-column-start: 2; grid-column-end: 5;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer bg-card"
@@ -1067,7 +1111,7 @@
         </div>
         <div
           class="relative"
-          style="width: calc(75.00% - 20px); height: 20px;"
+          style="width: calc(66.67% - 20px); height: 20px;"
         >
           <span
             class="absolute left-0 top-0"
@@ -1125,9 +1169,33 @@
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer bg-card"
         >
-          3
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
       </div>
+      <div />
       <div />
       <div />
       <div />
@@ -1159,20 +1227,42 @@
           />
         </div>
       </div>
-      <div />
       <div
         class="flex items-center justify-center z-10 relative text-asset-transfer"
         data-state="closed"
-        style="grid-column-start: 3; grid-column-end: 7;"
+        style="grid-column-start: 2; grid-column-end: 7;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer bg-card"
         >
-          1
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
         <div
           class="relative"
-          style="width: calc(75.00% - 20px); height: 20px;"
+          style="width: calc(80.00% - 20px); height: 20px;"
         >
           <div
             class="border-asset-transfer"
@@ -1266,20 +1356,42 @@
           />
         </div>
       </div>
-      <div />
       <div
         class="flex items-center justify-center z-10 relative text-application-call"
         data-state="closed"
-        style="grid-column-start: 3; grid-column-end: 6;"
+        style="grid-column-start: 2; grid-column-end: 6;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-application-call bg-card"
         >
-          1
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
         <div
           class="relative"
-          style="width: calc(66.67% - 20px); height: 20px;"
+          style="width: calc(75.00% - 20px); height: 20px;"
         >
           <div
             class="border-application-call"
@@ -1354,7 +1466,7 @@
       <div
         class="flex items-center justify-center z-10 relative text-asset-transfer"
         data-state="closed"
-        style="grid-column-start: 2; grid-column-end: 6;"
+        style="grid-column-start: 2; grid-column-end: 7;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer bg-card"
@@ -1363,7 +1475,7 @@
         </div>
         <div
           class="relative"
-          style="width: calc(75.00% - 20px); height: 20px;"
+          style="width: calc(80.00% - 20px); height: 20px;"
         >
           <span
             class="absolute left-0 top-0"
@@ -1421,10 +1533,32 @@
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer bg-card"
         >
-          5
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
       </div>
-      <div />
       <div />
       <div />
       <div
@@ -1455,20 +1589,42 @@
           />
         </div>
       </div>
-      <div />
       <div
         class="flex items-center justify-center z-10 relative text-asset-transfer"
         data-state="closed"
-        style="grid-column-start: 3; grid-column-end: 8;"
+        style="grid-column-start: 2; grid-column-end: 8;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer bg-card"
         >
-          1
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
         <div
           class="relative"
-          style="width: calc(80.00% - 20px); height: 20px;"
+          style="width: calc(83.33% - 20px); height: 20px;"
         >
           <div
             class="border-asset-transfer"
@@ -1561,20 +1717,42 @@
           />
         </div>
       </div>
-      <div />
       <div
         class="flex items-center justify-center z-10 relative text-application-call"
         data-state="closed"
-        style="grid-column-start: 3; grid-column-end: 6;"
+        style="grid-column-start: 2; grid-column-end: 6;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-application-call bg-card"
         >
-          1
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
         <div
           class="relative"
-          style="width: calc(66.67% - 20px); height: 20px;"
+          style="width: calc(75.00% - 20px); height: 20px;"
         >
           <div
             class="border-application-call"
@@ -1649,7 +1827,7 @@
       <div
         class="flex items-center justify-center z-10 relative text-asset-transfer"
         data-state="closed"
-        style="grid-column-start: 2; grid-column-end: 6;"
+        style="grid-column-start: 2; grid-column-end: 8;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer bg-card"
@@ -1658,7 +1836,7 @@
         </div>
         <div
           class="relative"
-          style="width: calc(75.00% - 20px); height: 20px;"
+          style="width: calc(83.33% - 20px); height: 20px;"
         >
           <span
             class="absolute left-0 top-0"
@@ -1716,11 +1894,32 @@
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer bg-card"
         >
-          6
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
       </div>
-      <div />
-      <div />
       <div />
       <div
         class="p-0 relative"
@@ -1750,20 +1949,42 @@
           />
         </div>
       </div>
-      <div />
       <div
         class="flex items-center justify-center z-10 relative text-asset-transfer"
         data-state="closed"
-        style="grid-column-start: 3; grid-column-end: 9;"
+        style="grid-column-start: 2; grid-column-end: 9;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer bg-card"
         >
-          1
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
         <div
           class="relative"
-          style="width: calc(83.33% - 20px); height: 20px;"
+          style="width: calc(85.71% - 20px); height: 20px;"
         >
           <div
             class="border-asset-transfer"
@@ -1855,20 +2076,42 @@
           />
         </div>
       </div>
-      <div />
       <div
         class="flex items-center justify-center z-10 relative text-application-call"
         data-state="closed"
-        style="grid-column-start: 3; grid-column-end: 9;"
+        style="grid-column-start: 2; grid-column-end: 9;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-application-call bg-card"
         >
-          1
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
         <div
           class="relative"
-          style="width: calc(83.33% - 20px); height: 20px;"
+          style="width: calc(85.71% - 20px); height: 20px;"
         >
           <div
             class="border-application-call"
@@ -2043,49 +2286,68 @@
         </div>
       </div>
       <div
-        class="flex items-center justify-center z-10 relative text-payment"
+        class="flex items-center justify-center relative z-10 text-payment"
         data-state="closed"
         style="grid-column-start: 2; grid-column-end: 4;"
       >
         <div
-          class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-payment bg-card"
+          class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-payment z-10 bg-card"
         >
-          1
-        </div>
-        <div
-          class="relative"
-          style="width: calc(50.00% - 20px); height: 20px;"
-        >
-          <span
-            class="absolute left-0 top-0"
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              height="20px"
-              preserveAspectRatio="xMinYMid meet"
-              viewBox="0 0 20 20"
-              width="20px"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlns:xlink="http://www.w3.org/1999/xlink"
-            >
-              <path
-                d="M 14 15 L 20 10 L 14 5 L 14 10 L 14 16 Z"
-                fill="currentColor"
-                fill-rule="nonzero"
-                stroke="none"
-                transform="scale(-1, 1) translate(-20, 0)"
-              />
-            </svg>
-          </span>
-          <div
-            class="border-payment"
-            style="height: calc(50% + 0.5px); border-bottom-width: 1px; margin: 0px 0px 0px 1px;"
-          />
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
         <div
-          class="absolute flex max-w-[35%] justify-center "
+          style="width: 50%; height: 20px;"
+        >
+          <svg
+            class="relative"
+            height="20px"
+            preserveAspectRatio="xMinYMid meet"
+            viewBox="0 0 20 20"
+            width="20px"
+            xmlns="http://www.w3.org/2000/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <path
+              d="M 14 15 L 20 10 L 14 5 L 14 10 L 14 16 Z"
+              fill="currentColor"
+              fill-rule="nonzero"
+              stroke="none"
+              transform="scale(-1, 1) translate(-20, 0)"
+            />
+          </svg>
+        </div>
+        <div
+          class="absolute size-1/2 border-payment"
+          style="border-width: 1px; border-radius: 4px; bottom: 0.5px; right: 25%;"
+        />
+        <div
+          class="absolute flex w-1/2 justify-center text-xs"
         >
           <div
-            class="z-20 p-0.5 text-xs text-center w-full bg-card"
+            class="z-20 p-0.5 text-xs text-center bg-card"
           >
             <span>
               Payment
@@ -2116,11 +2378,6 @@
               </svg>
             </div>
           </div>
-        </div>
-        <div
-          class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-payment bg-card"
-        >
-          1
         </div>
       </div>
       <div />

--- a/src/features/transactions-graph/components/__snapshots__/application-transaction-graph.WYEGSIGWZHTR6VYXC3EXFGZQHYKI6FQOZU2DOKHQCAWYEIHJBKEA.html
+++ b/src/features/transactions-graph/components/__snapshots__/application-transaction-graph.WYEGSIGWZHTR6VYXC3EXFGZQHYKI6FQOZU2DOKHQCAWYEIHJBKEA.html
@@ -1045,7 +1045,7 @@
       <div
         class="flex items-center justify-center z-10 relative text-payment"
         data-state="closed"
-        style="grid-column-start: 3; grid-column-end: 7;"
+        style="grid-column-start: 3; grid-column-end: 6;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-payment bg-card"
@@ -1054,7 +1054,7 @@
         </div>
         <div
           class="relative"
-          style="width: calc(75.00% - 20px); height: 20px;"
+          style="width: calc(66.67% - 20px); height: 20px;"
         >
           <span
             class="absolute left-0 top-0"
@@ -1120,9 +1120,33 @@
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-payment bg-card"
         >
-          4
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
       </div>
+      <div />
     </div>
   </div>
   <div

--- a/src/features/transactions-graph/components/__snapshots__/group-graph.%2BRd88080lmrfzu8EX6pntMRcOvv8AZOpxpQB1wr1h2Y%3D.html
+++ b/src/features/transactions-graph/components/__snapshots__/group-graph.%2BRd88080lmrfzu8EX6pntMRcOvv8AZOpxpQB1wr1h2Y%3D.html
@@ -547,7 +547,9 @@
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer z-10 bg-card"
-        />
+        >
+          1
+        </div>
         <div
           style="width: 50%; height: 20px;"
         >

--- a/src/features/transactions-graph/components/__snapshots__/group-graph.%2FoRSr2uMFemQhwQliJO18b64Nl1QIkjA39ZszRCeSCI%3D.html
+++ b/src/features/transactions-graph/components/__snapshots__/group-graph.%2FoRSr2uMFemQhwQliJO18b64Nl1QIkjA39ZszRCeSCI%3D.html
@@ -853,20 +853,42 @@
           />
         </div>
       </div>
-      <div />
       <div
         class="flex items-center justify-center z-10 relative text-payment"
         data-state="closed"
-        style="grid-column-start: 3; grid-column-end: 5;"
+        style="grid-column-start: 2; grid-column-end: 5;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-payment bg-card"
         >
-          1
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
         <div
           class="relative"
-          style="width: calc(50.00% - 20px); height: 20px;"
+          style="width: calc(66.67% - 20px); height: 20px;"
         >
           <div
             class="border-payment"
@@ -970,20 +992,42 @@
           />
         </div>
       </div>
-      <div />
       <div
         class="flex items-center justify-center z-10 relative text-application-call"
         data-state="closed"
-        style="grid-column-start: 3; grid-column-end: 6;"
+        style="grid-column-start: 2; grid-column-end: 6;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-application-call bg-card"
         >
-          1
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
         <div
           class="relative"
-          style="width: calc(66.67% - 20px); height: 20px;"
+          style="width: calc(75.00% - 20px); height: 20px;"
         >
           <div
             class="border-application-call"
@@ -1058,7 +1102,7 @@
       <div
         class="flex items-center justify-center z-10 relative text-asset-transfer"
         data-state="closed"
-        style="grid-column-start: 2; grid-column-end: 6;"
+        style="grid-column-start: 2; grid-column-end: 5;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer bg-card"
@@ -1067,7 +1111,7 @@
         </div>
         <div
           class="relative"
-          style="width: calc(75.00% - 20px); height: 20px;"
+          style="width: calc(66.67% - 20px); height: 20px;"
         >
           <span
             class="absolute left-0 top-0"
@@ -1125,9 +1169,33 @@
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer bg-card"
         >
-          3
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
       </div>
+      <div />
       <div />
       <div />
       <div />
@@ -1159,20 +1227,42 @@
           />
         </div>
       </div>
-      <div />
       <div
         class="flex items-center justify-center z-10 relative text-asset-transfer"
         data-state="closed"
-        style="grid-column-start: 3; grid-column-end: 7;"
+        style="grid-column-start: 2; grid-column-end: 7;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer bg-card"
         >
-          1
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
         <div
           class="relative"
-          style="width: calc(75.00% - 20px); height: 20px;"
+          style="width: calc(80.00% - 20px); height: 20px;"
         >
           <div
             class="border-asset-transfer"
@@ -1266,20 +1356,42 @@
           />
         </div>
       </div>
-      <div />
       <div
         class="flex items-center justify-center z-10 relative text-application-call"
         data-state="closed"
-        style="grid-column-start: 3; grid-column-end: 6;"
+        style="grid-column-start: 2; grid-column-end: 6;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-application-call bg-card"
         >
-          1
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
         <div
           class="relative"
-          style="width: calc(66.67% - 20px); height: 20px;"
+          style="width: calc(75.00% - 20px); height: 20px;"
         >
           <div
             class="border-application-call"
@@ -1354,7 +1466,7 @@
       <div
         class="flex items-center justify-center z-10 relative text-asset-transfer"
         data-state="closed"
-        style="grid-column-start: 2; grid-column-end: 6;"
+        style="grid-column-start: 2; grid-column-end: 7;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer bg-card"
@@ -1363,7 +1475,7 @@
         </div>
         <div
           class="relative"
-          style="width: calc(75.00% - 20px); height: 20px;"
+          style="width: calc(80.00% - 20px); height: 20px;"
         >
           <span
             class="absolute left-0 top-0"
@@ -1421,10 +1533,32 @@
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer bg-card"
         >
-          5
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
       </div>
-      <div />
       <div />
       <div />
       <div
@@ -1455,20 +1589,42 @@
           />
         </div>
       </div>
-      <div />
       <div
         class="flex items-center justify-center z-10 relative text-asset-transfer"
         data-state="closed"
-        style="grid-column-start: 3; grid-column-end: 8;"
+        style="grid-column-start: 2; grid-column-end: 8;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer bg-card"
         >
-          1
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
         <div
           class="relative"
-          style="width: calc(80.00% - 20px); height: 20px;"
+          style="width: calc(83.33% - 20px); height: 20px;"
         >
           <div
             class="border-asset-transfer"
@@ -1561,20 +1717,42 @@
           />
         </div>
       </div>
-      <div />
       <div
         class="flex items-center justify-center z-10 relative text-application-call"
         data-state="closed"
-        style="grid-column-start: 3; grid-column-end: 6;"
+        style="grid-column-start: 2; grid-column-end: 6;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-application-call bg-card"
         >
-          1
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
         <div
           class="relative"
-          style="width: calc(66.67% - 20px); height: 20px;"
+          style="width: calc(75.00% - 20px); height: 20px;"
         >
           <div
             class="border-application-call"
@@ -1649,7 +1827,7 @@
       <div
         class="flex items-center justify-center z-10 relative text-asset-transfer"
         data-state="closed"
-        style="grid-column-start: 2; grid-column-end: 6;"
+        style="grid-column-start: 2; grid-column-end: 8;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer bg-card"
@@ -1658,7 +1836,7 @@
         </div>
         <div
           class="relative"
-          style="width: calc(75.00% - 20px); height: 20px;"
+          style="width: calc(83.33% - 20px); height: 20px;"
         >
           <span
             class="absolute left-0 top-0"
@@ -1716,11 +1894,32 @@
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer bg-card"
         >
-          6
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
       </div>
-      <div />
-      <div />
       <div />
       <div
         class="p-0 relative"
@@ -1750,20 +1949,42 @@
           />
         </div>
       </div>
-      <div />
       <div
         class="flex items-center justify-center z-10 relative text-asset-transfer"
         data-state="closed"
-        style="grid-column-start: 3; grid-column-end: 9;"
+        style="grid-column-start: 2; grid-column-end: 9;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-asset-transfer bg-card"
         >
-          1
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
         <div
           class="relative"
-          style="width: calc(83.33% - 20px); height: 20px;"
+          style="width: calc(85.71% - 20px); height: 20px;"
         >
           <div
             class="border-asset-transfer"
@@ -1855,20 +2076,42 @@
           />
         </div>
       </div>
-      <div />
       <div
         class="flex items-center justify-center z-10 relative text-application-call"
         data-state="closed"
-        style="grid-column-start: 3; grid-column-end: 9;"
+        style="grid-column-start: 2; grid-column-end: 9;"
       >
         <div
           class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-application-call bg-card"
         >
-          1
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
         <div
           class="relative"
-          style="width: calc(83.33% - 20px); height: 20px;"
+          style="width: calc(85.71% - 20px); height: 20px;"
         >
           <div
             class="border-application-call"
@@ -2043,49 +2286,68 @@
         </div>
       </div>
       <div
-        class="flex items-center justify-center z-10 relative text-payment"
+        class="flex items-center justify-center relative z-10 text-payment"
         data-state="closed"
         style="grid-column-start: 2; grid-column-end: 4;"
       >
         <div
-          class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-payment bg-card"
+          class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-payment z-10 bg-card"
         >
-          1
-        </div>
-        <div
-          class="relative"
-          style="width: calc(50.00% - 20px); height: 20px;"
-        >
-          <span
-            class="absolute left-0 top-0"
+          <svg
+            class="lucide lucide-key "
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              height="20px"
-              preserveAspectRatio="xMinYMid meet"
-              viewBox="0 0 20 20"
-              width="20px"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlns:xlink="http://www.w3.org/1999/xlink"
-            >
-              <path
-                d="M 14 15 L 20 10 L 14 5 L 14 10 L 14 16 Z"
-                fill="currentColor"
-                fill-rule="nonzero"
-                stroke="none"
-                transform="scale(-1, 1) translate(-20, 0)"
-              />
-            </svg>
-          </span>
-          <div
-            class="border-payment"
-            style="height: calc(50% + 0.5px); border-bottom-width: 1px; margin: 0px 0px 0px 1px;"
-          />
+            <circle
+              cx="7.5"
+              cy="15.5"
+              r="5.5"
+            />
+            <path
+              d="m21 2-9.6 9.6"
+            />
+            <path
+              d="m15.5 7.5 3 3L22 7l-3-3"
+            />
+          </svg>
         </div>
         <div
-          class="absolute flex max-w-[35%] justify-center "
+          style="width: 50%; height: 20px;"
+        >
+          <svg
+            class="relative"
+            height="20px"
+            preserveAspectRatio="xMinYMid meet"
+            viewBox="0 0 20 20"
+            width="20px"
+            xmlns="http://www.w3.org/2000/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <path
+              d="M 14 15 L 20 10 L 14 5 L 14 10 L 14 16 Z"
+              fill="currentColor"
+              fill-rule="nonzero"
+              stroke="none"
+              transform="scale(-1, 1) translate(-20, 0)"
+            />
+          </svg>
+        </div>
+        <div
+          class="absolute size-1/2 border-payment"
+          style="border-width: 1px; border-radius: 4px; bottom: 0.5px; right: 25%;"
+        />
+        <div
+          class="absolute flex w-1/2 justify-center text-xs"
         >
           <div
-            class="z-20 p-0.5 text-xs text-center w-full bg-card"
+            class="z-20 p-0.5 text-xs text-center bg-card"
           >
             <span>
               Payment
@@ -2116,11 +2378,6 @@
               </svg>
             </div>
           </div>
-        </div>
-        <div
-          class="inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem] border-payment bg-card"
-        >
-          1
         </div>
       </div>
       <div />

--- a/src/features/transactions-graph/components/horizontal.tsx
+++ b/src/features/transactions-graph/components/horizontal.tsx
@@ -1,6 +1,6 @@
 import { fixedForwardRef } from '@/utils/fixed-forward-ref'
 import { AppCallTransaction, InnerAppCallTransaction, InnerTransaction, Transaction, TransactionType } from '@/features/transactions/models'
-import { Horizontal as HorizontalModel, LabelType, Point, RepresentationType, SelfLoop, Vector, Vertical } from '../models'
+import { Horizontal as HorizontalModel, LabelType, Point, MarkerTag, RepresentationType, SelfLoop, Vector, Vertical } from '../models'
 import { graphConfig } from '@/features/transactions-graph/components/graph-config'
 import { cn } from '@/features/common/utils'
 import SvgPointerLeft from '@/features/common/components/svg/pointer-left'
@@ -20,6 +20,7 @@ import PointerRight from '@/features/common/components/svg/pointer-right'
 import { SubHorizontalTitle } from '@/features/transactions-graph/components/sub-horizontal-title'
 import { RenderAsyncAtom } from '@/features/common/components/render-async-atom'
 import { HeartbeatTransactionTooltipContent } from './heartbeat-transaction-tooltip-content'
+import { KeyIcon } from 'lucide-react'
 
 function ConnectionsFromAncestorsToAncestorsNextSiblings({ ancestors }: { ancestors: HorizontalModel[] }) {
   return ancestors
@@ -46,12 +47,12 @@ const colorClassMap = {
   [TransactionType.Heartbeat]: { border: 'border-heartbeat', text: 'text-heartbeat' },
 }
 
-function Circle({ className, text }: { className?: string; text?: string | number }) {
+function Marker({ className, tag }: { className?: string; tag?: MarkerTag }) {
   return (
     <div
       className={cn('inline-flex relative size-5 items-center justify-center overflow-hidden rounded-full border text-[0.6rem]', className)}
     >
-      {text}
+      {tag === 'Rekey' ? <KeyIcon size={10} /> : tag}
     </div>
   )
 }
@@ -177,10 +178,7 @@ const RenderTransactionVector = fixedForwardRef(
         ref={ref}
         {...rest}
       >
-        <Circle
-          className={cn(colorClass.border, bgClassName)}
-          text={vector.direction === 'leftToRight' ? vector.fromAccountIndex : vector.toAccountIndex}
-        />
+        <Marker className={cn(colorClass.border, bgClassName)} tag={vector.direction === 'leftToRight' ? vector.fromTag : vector.toTag} />
         <div
           style={{
             width: `calc(${(100 - 100 / (vector.toVerticalIndex - vector.fromVerticalIndex + 1)).toFixed(2)}% - ${graphConfig.circleDimension}px)`,
@@ -212,10 +210,7 @@ const RenderTransactionVector = fixedForwardRef(
             <VectorLabel transaction={transaction} vector={vector} />
           </div>
         </div>
-        <Circle
-          className={cn(colorClass.border, bgClassName)}
-          text={vector.direction === 'leftToRight' ? vector.toAccountIndex : vector.fromAccountIndex}
-        />
+        <Marker className={cn(colorClass.border, bgClassName)} tag={vector.direction === 'leftToRight' ? vector.toTag : vector.fromTag} />
       </div>
     )
   }
@@ -246,10 +241,7 @@ const RenderTransactionSelfLoop = fixedForwardRef(
           gridColumnEnd: loop.fromVerticalIndex + 4, // 4 to offset the name column and make this cell span 2 columns
         }}
       >
-        <Circle
-          className={cn(colorClass.border, 'z-10', bgClassName)}
-          text={loop.fromAccountIndex === loop.toAccountIndex ? loop.fromAccountIndex : undefined}
-        />
+        <Marker className={cn(colorClass.border, 'z-10', bgClassName)} tag={loop.fromTag} />
         <div
           style={{
             width: `50%`,
@@ -303,7 +295,7 @@ const RenderTransactionPoint = fixedForwardRef(
           gridColumnEnd: point.fromVerticalIndex + 3,
         }}
       >
-        <Circle className={cn(colorClass.border, bgClassName)} />
+        <Marker className={cn(colorClass.border, bgClassName)} />
       </div>
     )
   }

--- a/src/features/transactions-graph/models/index.ts
+++ b/src/features/transactions-graph/models/index.ts
@@ -76,12 +76,14 @@ export type Label =
   | { type: LabelType.StateProof }
   | { type: LabelType.Heartbeat }
 
+export type MarkerTag = number | 'Rekey'
+
 export type Vector = {
   type: RepresentationType.Vector
   label: Label
   fromVerticalIndex: number
-  fromAccountIndex?: number
-  toAccountIndex?: number
+  fromTag?: MarkerTag
+  toTag?: MarkerTag
   toVerticalIndex: number
   direction: 'leftToRight' | 'rightToLeft'
 }
@@ -90,15 +92,15 @@ export type SelfLoop = {
   type: RepresentationType.SelfLoop
   label: Label
   fromVerticalIndex: number
-  fromAccountIndex?: number
-  toAccountIndex?: number
+  fromTag?: MarkerTag
+  toTag?: MarkerTag
 }
 
 export type Point = {
   type: RepresentationType.Point
   label: Label
   fromVerticalIndex: number
-  fromAccountIndex?: number
+  fromTag?: MarkerTag
 }
 
 type AssociatedAccount = {
@@ -146,10 +148,10 @@ export type Vertical = AccountVertical | ApplicationVertical | AssetVertical | O
 
 export type RepresentationFromTo = {
   verticalId: number
-  accountNumber?: number
+  tag?: MarkerTag
 }
 // Fallback value, it should never happen, just to make TypeScript happy
 export const fallbackFromTo: RepresentationFromTo = {
   verticalId: -1,
-  accountNumber: undefined,
+  tag: undefined,
 }


### PR DESCRIPTION
Adjust how we visually represent transactions from rekeyed accounts that are initiated by applications.

Simple Before
![simple_before](https://github.com/user-attachments/assets/d07ac493-6ee8-46f3-b8af-18453f200ddb)

Simple After
![simple_after](https://github.com/user-attachments/assets/9c46f479-e620-495a-a553-b587e0eada21)


Complex Before
![complex_before](https://github.com/user-attachments/assets/088984d5-1406-4ab5-a997-615cc61e444a)

Complex After
![complex_after](https://github.com/user-attachments/assets/efd99a1e-a693-46f3-888b-25e083994da4)
