### PR TITLE
chore: move tracking script to ensure it doesn't interfere when blocked

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="AlgoKit lora, the Algorand live on-chain resource analyzer." />
     <meta name="name" content="AlgoKit - lora" />
+    <title>AlgoKit - lora</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
     <script
       defer
       data-domain="lora.algokit.io"
@@ -24,11 +29,5 @@
           ;(window.plausible.q = window.plausible.q || []).push(arguments)
         }
     </script>
-
-    <title>AlgoKit - lora</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
Moved the tracking script to just before the </body> so that any kind of blocking script doesn't interfere with page loading.