### PR TITLE
feat: store data table page sizes

### DIFF
--- a/src/features/accounts/components/account-applications.tsx
+++ b/src/features/accounts/components/account-applications.tsx
@@ -18,5 +18,5 @@ const applicationsTableColumns: ColumnDef<ApplicationSummary>[] = [
 ]
 
 export function AccountApplications({ applications }: Props) {
-  return <DataTable columns={applicationsTableColumns} data={applications} />
+  return <DataTable columns={applicationsTableColumns} data={applications} dataContext="application" />
 }

--- a/src/features/accounts/components/account-assets-created.tsx
+++ b/src/features/accounts/components/account-assets-created.tsx
@@ -36,5 +36,5 @@ const assetsCreatedTableColumns: ColumnDef<AccountAssetSummary>[] = [
 ]
 
 export function AccountAssetsCreated({ assetsCreated }: Props) {
-  return <DataTable columns={assetsCreatedTableColumns} data={assetsCreated} />
+  return <DataTable columns={assetsCreatedTableColumns} data={assetsCreated} dataContext="asset" />
 }

--- a/src/features/accounts/components/account-assets-held.tsx
+++ b/src/features/accounts/components/account-assets-held.tsx
@@ -7,5 +7,5 @@ type Props = {
 }
 
 export function AccountAssetsHeld({ assetsHeld }: Props) {
-  return <DataTable columns={accountAssetHoldingsTableColumns} data={assetsHeld} />
+  return <DataTable columns={accountAssetHoldingsTableColumns} data={assetsHeld} dataContext="asset" />
 }

--- a/src/features/accounts/components/account-assets-opted.tsx
+++ b/src/features/accounts/components/account-assets-opted.tsx
@@ -7,5 +7,5 @@ type Props = {
 }
 
 export function AccountAssetsOpted({ assetsOpted }: Props) {
-  return <DataTable columns={accountAssetHoldingsTableColumns} data={assetsOpted} />
+  return <DataTable columns={accountAssetHoldingsTableColumns} data={assetsOpted} dataContext="asset" />
 }

--- a/src/features/accounts/components/account-transaction-history.tsx
+++ b/src/features/accounts/components/account-transaction-history.tsx
@@ -17,7 +17,12 @@ export function AccountTransactionHistory({ address }: Props) {
 
   return (
     <div>
-      <LazyLoadDataTable columns={transactionsTableColumns} getSubRows={getSubRows} createLoadablePage={createLoadablePage} />
+      <LazyLoadDataTable
+        columns={transactionsTableColumns}
+        getSubRows={getSubRows}
+        createLoadablePage={createLoadablePage}
+        dataContext="transaction"
+      />
       <ListingOrderLabel oldestToNewest={false} />
     </div>
   )

--- a/src/features/app-interfaces/components/edit/app-specs-table.tsx
+++ b/src/features/app-interfaces/components/edit/app-specs-table.tsx
@@ -81,7 +81,7 @@ export function AppSpecsTable({ appInterface, refreshAppInterface }: Props) {
         <h2 className="pb-0">{appSpecsLabel}</h2>
         <AddAppSpecButton applicationId={appInterface.applicationId} onSuccess={refreshAppInterface} />
       </div>
-      <DataTable ariaLabel={appSpecsLabel} columns={tableColumns} data={appInterface.appSpecVersions} />
+      <DataTable ariaLabel={appSpecsLabel} columns={tableColumns} data={appInterface.appSpecVersions} dataContext="appSpec" />
     </div>
   )
 }

--- a/src/features/applications/components/application-box-details-dialog.tsx
+++ b/src/features/applications/components/application-box-details-dialog.tsx
@@ -47,7 +47,12 @@ function InternalDialogContent({ application, boxDescriptor }: { application: Ap
   return (
     <RenderLoadable loadable={loadableApplicationBox}>
       {(applicationBox) => (
-        <DataTable columns={boxTableColumns} data={[{ boxDescriptor, boxValue: applicationBox }]} hidePagination={true} />
+        <DataTable
+          columns={boxTableColumns}
+          data={[{ boxDescriptor, boxValue: applicationBox }]}
+          hidePagination={true}
+          dataContext="applicationState"
+        />
       )}
     </RenderLoadable>
   )

--- a/src/features/applications/components/application-boxes.tsx
+++ b/src/features/applications/components/application-boxes.tsx
@@ -14,7 +14,7 @@ export function ApplicationBoxes({ application }: Props) {
   const createLoadablePage = useMemo(() => createLoadableApplicationBoxesPage(application), [application])
   const tableColumns = useMemo(() => createTableColumns(application), [application])
 
-  return <LazyLoadDataTable columns={tableColumns} createLoadablePage={createLoadablePage} />
+  return <LazyLoadDataTable columns={tableColumns} createLoadablePage={createLoadablePage} dataContext="applicationState" />
 }
 
 const createTableColumns = (application: Application): ColumnDef<BoxDescriptor>[] => {

--- a/src/features/applications/components/application-global-state-table.tsx
+++ b/src/features/applications/components/application-global-state-table.tsx
@@ -12,9 +12,9 @@ type Props = {
 export function ApplicationGlobalStateTable({ application }: Props) {
   const component = useMemo(() => {
     if (application.globalState?.every((state) => 'type' in state)) {
-      return <DataTable columns={rawTableColumns} data={application.globalState ?? []} />
+      return <DataTable columns={rawTableColumns} data={application.globalState ?? []} dataContext="applicationState" />
     }
-    return <DataTable columns={decodedTableColumns} data={application.globalState ?? []} />
+    return <DataTable columns={decodedTableColumns} data={application.globalState ?? []} dataContext="applicationState" />
   }, [application.globalState])
 
   return component

--- a/src/features/applications/components/application-transaction-history.tsx
+++ b/src/features/applications/components/application-transaction-history.tsx
@@ -26,7 +26,12 @@ export function ApplicationTransactionHistory({ applicationId }: Props) {
 
   return (
     <div>
-      <LazyLoadDataTable columns={transactionsTableColumns} getSubRows={getSubRows} createLoadablePage={createLoadablePage} />
+      <LazyLoadDataTable
+        columns={transactionsTableColumns}
+        getSubRows={getSubRows}
+        createLoadablePage={createLoadablePage}
+        dataContext="transaction"
+      />
       <ListingOrderLabel />
     </div>
   )

--- a/src/features/assets/components/asset-transaction-history.tsx
+++ b/src/features/assets/components/asset-transaction-history.tsx
@@ -17,7 +17,12 @@ export function AssetTransactionHistory({ assetId }: Props) {
 
   return (
     <div>
-      <LazyLoadDataTable columns={transactionsTableColumns} getSubRows={getSubRows} createLoadablePage={createLoadablePage} />
+      <LazyLoadDataTable
+        columns={transactionsTableColumns}
+        getSubRows={getSubRows}
+        createLoadablePage={createLoadablePage}
+        dataContext="transaction"
+      />
       <ListingOrderLabel />
     </div>
   )

--- a/src/features/common/components/data-table-pagination.tsx
+++ b/src/features/common/components/data-table-pagination.tsx
@@ -2,12 +2,11 @@ import { Table } from '@tanstack/react-table'
 import { Button } from '@/features/common/components/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/features/common/components/select'
 import { ChevronFirst, ChevronLast, ChevronLeft, ChevronRight } from 'lucide-react'
+import { pageSizeOptions } from '../../settings/data/table-page-sizes'
 
 interface DataTablePaginationProps<TData> {
   table: Table<TData>
 }
-
-const pageSizeOptions = [10, 20, 30, 40, 50]
 
 export function DataTablePagination<TData>({ table }: DataTablePaginationProps<TData>) {
   return (

--- a/src/features/common/components/data-table.tsx
+++ b/src/features/common/components/data-table.tsx
@@ -11,6 +11,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { DataTablePagination } from './data-table-pagination'
 import { useEffect, useState } from 'react'
 import { cn } from '@/features/common/utils'
+import { TableDataContext, useTablePageSize } from '../../settings/data/table-page-sizes'
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
@@ -19,6 +20,7 @@ interface DataTableProps<TData, TValue> {
   subRowsExpanded?: boolean
   ariaLabel?: string
   hidePagination?: boolean
+  dataContext: TableDataContext
 }
 
 export function DataTable<TData, TValue>({
@@ -28,8 +30,11 @@ export function DataTable<TData, TValue>({
   subRowsExpanded,
   ariaLabel,
   hidePagination,
+  dataContext,
 }: DataTableProps<TData, TValue>) {
   const [expanded, setExpanded] = useState<ExpandedState>({})
+  const [pageSize, setPageSize] = useTablePageSize(dataContext)
+
   const table = useReactTable({
     data,
     paginateExpandedRows: false,
@@ -42,11 +47,26 @@ export function DataTable<TData, TValue>({
     getCoreRowModel: getCoreRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
+    initialState: {
+      pagination: {
+        pageSize: pageSize,
+      },
+    },
   })
+
+  const currentPageSize = table.getState().pagination.pageSize
 
   useEffect(() => {
     table.toggleAllRowsExpanded(subRowsExpanded ?? false)
   }, [subRowsExpanded, table])
+
+  useEffect(() => {
+    if (currentPageSize !== pageSize) {
+      setPageSize(currentPageSize)
+    }
+    // It's important not to include pageSize in the dependencies, otherwise it will cause an infinite loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentPageSize])
 
   return (
     <div>

--- a/src/features/common/components/lazy-load-data-table/lazy-load-data-table-pagination.tsx
+++ b/src/features/common/components/lazy-load-data-table/lazy-load-data-table-pagination.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/features/common/components/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/features/common/components/select'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { pageSizeOptions } from '../../../settings/data/table-page-sizes'
 
 interface Props {
   pageSize: number
@@ -11,8 +12,6 @@ interface Props {
   previousPageEnabled: boolean
   previousPage: () => void
 }
-
-const pageSizeOptions = [10, 20, 30, 40, 50]
 
 export function LazyLoadDataTablePagination({
   pageSize,

--- a/src/features/common/components/lazy-load-data-table/lazy-load-data-table.tsx
+++ b/src/features/common/components/lazy-load-data-table/lazy-load-data-table.tsx
@@ -6,16 +6,24 @@ import { Loader2 as Loader } from 'lucide-react'
 import { Loadable } from 'jotai/vanilla/utils/loadable'
 import { ViewModelPage } from '../../data/lazy-load-pagination'
 import { cn } from '../../utils'
+import { TableDataContext, useTablePageSize } from '../../../settings/data/table-page-sizes'
 
 interface Props<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
   createLoadablePage: (pageSize: number) => (pageNumber: number) => Loadable<Promise<ViewModelPage<TData>>>
   getSubRows?: (row: TData) => TData[]
   subRowsExpanded?: boolean
+  dataContext: TableDataContext
 }
 
-export function LazyLoadDataTable<TData, TValue>({ columns, createLoadablePage, getSubRows, subRowsExpanded }: Props<TData, TValue>) {
-  const [pageSize, setPageSize] = useState(10)
+export function LazyLoadDataTable<TData, TValue>({
+  columns,
+  createLoadablePage,
+  getSubRows,
+  subRowsExpanded,
+  dataContext,
+}: Props<TData, TValue>) {
+  const [pageSize, setPageSize] = useTablePageSize(dataContext)
   const useLoadablePage = useMemo(() => createLoadablePage(pageSize), [createLoadablePage, pageSize])
   const [currentPage, setCurrentPage] = useState<number>(1)
   const loadablePage = useLoadablePage(currentPage)
@@ -28,10 +36,13 @@ export function LazyLoadDataTable<TData, TValue>({ columns, createLoadablePage, 
     setCurrentPage((prev) => (prev > 1 ? prev - 1 : prev))
   }, [])
 
-  const setPageSizeAndResetCurrentPage = useCallback((newPageSize: number) => {
-    setPageSize(newPageSize)
-    setCurrentPage(1)
-  }, [])
+  const setPageSizeAndResetCurrentPage = useCallback(
+    (newPageSize: number) => {
+      setPageSize(newPageSize)
+      setCurrentPage(1)
+    },
+    [setPageSize]
+  )
 
   const page = useMemo(() => (loadablePage.state === 'hasData' ? loadablePage.data : undefined), [loadablePage])
 

--- a/src/features/network/components/network-configs-table.tsx
+++ b/src/features/network/components/network-configs-table.tsx
@@ -47,7 +47,7 @@ export function NetworkConfigsTable() {
           Create
         </Button>
       </div>
-      <DataTable ariaLabel={networkConfigsTableLabel} columns={tableColumns} data={data} />
+      <DataTable ariaLabel={networkConfigsTableLabel} columns={tableColumns} data={data} dataContext="networkConfig" />
       <Dialog open={createNetworkConfigDialogOpen} onOpenChange={setCreateNetworkConfigDialogOpen} modal={true}>
         {createNetworkConfigDialogOpen && (
           <DialogContent className="bg-card" aria-label={createNetworkConfigDialogLabel}>

--- a/src/features/settings/data/table-page-sizes.ts
+++ b/src/features/settings/data/table-page-sizes.ts
@@ -1,0 +1,31 @@
+import { useAtom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
+import { settingsStore } from '@/features/settings/data'
+
+export type TableDataContext = 'transaction' | 'application' | 'asset' | 'applicationState' | 'networkConfig' | 'appSpec'
+type TablePageSizes = Partial<Record<TableDataContext, PageSizeOption>>
+type PageSizeOption = (typeof pageSizeOptions)[number]
+
+export const pageSizeOptions = [10, 20, 30, 40, 50, 100] as const
+const tablePageSizesAtom = atomWithStorage<TablePageSizes>('table-page-sizes', {}, undefined, { getOnInit: true })
+const defaultPageSize: PageSizeOption = 10
+
+export const useTablePageSize = (context: TableDataContext) => {
+  const [tablePageSizes, setTablePageSizes] = useAtom(tablePageSizesAtom, { store: settingsStore })
+
+  const setPageSize = (pageSize: number) => {
+    if (!pageSizeOptions.includes(pageSize as PageSizeOption)) {
+      throw new Error(`Invalid page size: ${pageSize}. Must be one of ${pageSizeOptions.join(', ')}.`)
+    }
+    const nextPageSize = pageSizeOptions.includes(pageSize as PageSizeOption) ? (pageSize as PageSizeOption) : defaultPageSize
+
+    setTablePageSizes((prev) => ({
+      ...prev,
+      [context]: nextPageSize,
+    }))
+  }
+
+  const pageSize = tablePageSizes[context] ?? defaultPageSize
+
+  return [pageSize, setPageSize] as const
+}

--- a/src/features/transactions/components/app-call-transaction-info.tsx
+++ b/src/features/transactions/components/app-call-transaction-info.tsx
@@ -284,9 +284,9 @@ function GlobalStateDeltas({ transaction }: Props) {
 function GlobalStateTable({ data }: { data: GlobalStateDelta[] }) {
   const component = useMemo(() => {
     if (data.every((item) => 'type' in item)) {
-      return <DataTable columns={rawGlobalStateDeltaTableColumns} data={data} />
+      return <DataTable columns={rawGlobalStateDeltaTableColumns} data={data} dataContext="applicationState" />
     }
-    return <DataTable columns={decodedGlobalStateDeltaTableColumns} data={data} />
+    return <DataTable columns={decodedGlobalStateDeltaTableColumns} data={data} dataContext="applicationState" />
   }, [data])
 
   return component
@@ -374,9 +374,9 @@ function LocalStateDeltas({ transaction }: Props) {
 function LocalStateTable({ data }: { data: LocalStateDelta[] }) {
   const component = useMemo(() => {
     if (data.every((item) => 'type' in item)) {
-      return <DataTable columns={rawLocalStateDeltaTableColumns} data={data} />
+      return <DataTable columns={rawLocalStateDeltaTableColumns} data={data} dataContext="applicationState" />
     }
-    return <DataTable columns={decodedLocalStateDeltaTableColumns} data={data} />
+    return <DataTable columns={decodedLocalStateDeltaTableColumns} data={data} dataContext="applicationState" />
   }, [data])
 
   return component

--- a/src/features/transactions/components/live-transactions-table.tsx
+++ b/src/features/transactions/components/live-transactions-table.tsx
@@ -1,13 +1,14 @@
 import { ColumnDef, ExpandedState, flexRender, getCoreRowModel, getExpandedRowModel, useReactTable } from '@tanstack/react-table'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/features/common/components/table'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../common/components/select'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { InnerTransaction, Transaction } from '@/features/transactions/models'
 import { TransactionResult } from '@/features/transactions/data/types'
 import { useLiveTransactions } from '../data/live-transaction'
 import { cn } from '@/features/common/utils'
 import { Switch } from '@/features/common/components/switch'
 import { Label } from '@/features/common/components/label'
+import { pageSizeOptions, useTablePageSize } from '@/features/settings/data/table-page-sizes'
 
 interface Props {
   columns: ColumnDef<Transaction>[]
@@ -17,7 +18,7 @@ interface Props {
 
 export function LiveTransactionsTable({ filter, columns, getSubRows }: Props) {
   const [expanded, setExpanded] = useState<ExpandedState>({})
-  const [maxRows, setMaxRows] = useState(10)
+  const [maxRows, setMaxRows] = useTablePageSize('transaction')
   const { transactions, showLiveUpdates, setShowLiveUpdates } = useLiveTransactions(filter, maxRows)
 
   const table = useReactTable({
@@ -37,6 +38,13 @@ export function LiveTransactionsTable({ filter, columns, getSubRows }: Props) {
   useEffect(() => {
     table.toggleAllRowsExpanded(true)
   }, [table])
+
+  const updateMaxRows = useCallback(
+    (newMaxRows: string) => {
+      setMaxRows(Number(newMaxRows))
+    },
+    [setMaxRows]
+  )
 
   return (
     <div>
@@ -85,14 +93,14 @@ export function LiveTransactionsTable({ filter, columns, getSubRows }: Props) {
         <div className="flex">
           <div className="flex shrink grow basis-0 items-center justify-start gap-2">
             <p className="hidden text-sm font-medium md:flex">Max rows</p>
-            <Select value={`${maxRows}`} onValueChange={(value) => setMaxRows(Number(value))}>
+            <Select value={`${maxRows}`} onValueChange={updateMaxRows}>
               <SelectTrigger className="h-8 w-[70px]">
                 <SelectValue placeholder={`${maxRows}`} />
               </SelectTrigger>
               <SelectContent side="top">
-                {maxRowsOptions.map((option) => (
-                  <SelectItem key={option} value={`${option}`}>
-                    {option}
+                {pageSizeOptions.map((maxRows) => (
+                  <SelectItem key={maxRows} value={`${maxRows}`}>
+                    {maxRows}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -100,7 +108,7 @@ export function LiveTransactionsTable({ filter, columns, getSubRows }: Props) {
           </div>
         </div>
         <div className="ml-auto flex items-center space-x-2">
-          <Switch id="live-view-enabled" onCheckedChange={(checked) => setShowLiveUpdates(checked)} checked={showLiveUpdates} />
+          <Switch id="live-view-enabled" onCheckedChange={setShowLiveUpdates} checked={showLiveUpdates} />
           <Label htmlFor="live-view-enabled" className="cursor-pointer">
             Show updates
           </Label>
@@ -109,5 +117,3 @@ export function LiveTransactionsTable({ filter, columns, getSubRows }: Props) {
     </div>
   )
 }
-
-const maxRowsOptions = [10, 20, 30, 40, 50]

--- a/src/features/transactions/components/transactions-table.tsx
+++ b/src/features/transactions/components/transactions-table.tsx
@@ -16,5 +16,7 @@ const getSubRows = (transaction: Transaction | InnerTransaction) => {
 }
 
 export function TransactionsTable({ transactions, columns, subRowsExpanded }: Props) {
-  return <DataTable columns={columns} data={transactions} getSubRows={getSubRows} subRowsExpanded={subRowsExpanded} />
+  return (
+    <DataTable columns={columns} data={transactions} getSubRows={getSubRows} subRowsExpanded={subRowsExpanded} dataContext="transaction" />
+  )
 }


### PR DESCRIPTION
Store the selected page size so the user doesn't need to keep reselecting the setting they want.
The page size selection is stored based on table data context, so users have optionally to set the value based on the kind of data being viewed.

![page_sizes](https://github.com/user-attachments/assets/1b7baa18-be22-4500-8eee-d124ae1e161e)
