### PR TITLE
chore: make qr more scanable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17432,10 +17432,11 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
-      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },

--- a/src/features/accounts/components/address-qr-dialog-button.tsx
+++ b/src/features/accounts/components/address-qr-dialog-button.tsx
@@ -46,7 +46,9 @@ export function OpenAddressQRDialogButton({ address, className }: Props) {
                 <div className="flex w-full max-w-full items-center justify-center">
                   <span className="max-w-full truncate text-center">{address}</span>
                 </div>
-                <QRCode className="w-full" value={`algorand://${address}`} />
+                <div className="bg-white p-2">
+                  <QRCode className="w-full" value={`algorand://${address}`} />
+                </div>
                 <p>Scan the QR code to copy the address</p>
               </div>
             </MediumSizeDialogBody>


### PR DESCRIPTION
When using the qr codes in dark mode they don't always scan easily.
Putting a white border around them fixes the issue, which is what this PR does. 

Also fixed a low priority npm audit issue whilst I was there.