### PR TITLE
Added payment and asset create txn to url params AK-653 AK-654

### DIFF
--- a/src/features/transaction-wizard/components/asset-create-transaction-builder.tsx
+++ b/src/features/transaction-wizard/components/asset-create-transaction-builder.tsx
@@ -18,7 +18,7 @@ import { TransactionBuilderNoteField } from './transaction-builder-note-field'
 import { asAddressOrNfd, asOptionalAddressOrNfd } from '../mappers/as-address-or-nfd'
 import { ActiveWalletAccount } from '@/features/wallet/types/active-wallet'
 
-const formSchema = {
+export const assetCreateFormSchema = z.object({
   ...commonSchema,
   ...senderFieldSchema,
   total: bigIntSchema(z.bigint({ required_error: 'Required', invalid_type_error: 'Required' })),
@@ -32,9 +32,9 @@ const formSchema = {
   reserve: optionalAddressFieldSchema,
   freeze: optionalAddressFieldSchema,
   clawback: optionalAddressFieldSchema,
-}
+})
 
-const formData = zfd.formData(formSchema)
+const formData = zfd.formData(assetCreateFormSchema)
 
 type FormFieldsProps = {
   helper: FormFieldHelper<z.infer<typeof formData>>

--- a/src/features/transaction-wizard/components/asset-create-transaction-builder.tsx
+++ b/src/features/transaction-wizard/components/asset-create-transaction-builder.tsx
@@ -21,7 +21,7 @@ import { ActiveWalletAccount } from '@/features/wallet/types/active-wallet'
 export const assetCreateFormSchema = z.object({
   ...commonSchema,
   ...senderFieldSchema,
-  total: bigIntSchema(z.bigint({ required_error: 'Required', invalid_type_error: 'Required' })),
+  total: bigIntSchema(z.bigint({ required_error: 'Required', invalid_type_error: 'Required' }).gt(BigInt(0), 'Must be greater than 0')),
   decimals: numberSchema(z.number({ required_error: 'Required', invalid_type_error: 'Required' }).min(0).max(19)),
   assetName: zfd.text(z.string().optional()),
   unitName: zfd.text(z.string().optional()),

--- a/src/features/transaction-wizard/components/payment-transaction-builder.tsx
+++ b/src/features/transaction-wizard/components/payment-transaction-builder.tsx
@@ -20,13 +20,13 @@ import { ActiveWalletAccount } from '@/features/wallet/types/active-wallet'
 
 const receiverLabel = 'Receiver'
 
-const formSchema = {
+export const paymentFormSchema = z.object({
   ...commonSchema,
   ...senderFieldSchema,
   ...receiverFieldSchema,
   amount: numberSchema(z.number({ required_error: 'Required', invalid_type_error: 'Required' }).min(0)),
-}
-const formData = zfd.formData(formSchema)
+})
+const formData = zfd.formData(paymentFormSchema)
 
 type Props = {
   mode: TransactionBuilderMode

--- a/src/features/transaction-wizard/utils/transactions-url-search-params.test.tsx
+++ b/src/features/transaction-wizard/utils/transactions-url-search-params.test.tsx
@@ -1,9 +1,10 @@
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest'
 import { TransactionWizardPage } from '../transaction-wizard-page'
-import { render, screen } from '@testing-library/react'
+import { render, screen, cleanup } from '@testing-library/react'
 import { algorandFixture } from '@algorandfoundation/algokit-utils/testing'
 import { TooltipProvider } from '@/features/common/components/tooltip'
+import { ToastContainer } from 'react-toastify'
 
 const renderTxnsWizardPageWithSearchParams = ({ searchParams }: { searchParams: URLSearchParams }) => {
   const urlSearchParams = new URLSearchParams(searchParams).toString()
@@ -12,9 +13,12 @@ const renderTxnsWizardPageWithSearchParams = ({ searchParams }: { searchParams: 
       {
         path: '/localnet/transaction-wizard',
         element: (
-          <TooltipProvider>
-            <TransactionWizardPage />
-          </TooltipProvider>
+          <>
+            <ToastContainer />
+            <TooltipProvider>
+              <TransactionWizardPage />
+            </TooltipProvider>
+          </>
         ),
       },
     ],
@@ -112,6 +116,152 @@ describe('Render transactions page with search params', () => {
       expect(screen.getByText(votekey)).toBeInTheDocument()
       expect(screen.getByText(votelst.toString())).toBeInTheDocument()
       expect(screen.getByText('2')).toBeInTheDocument()
+    })
+  })
+
+  describe('payment transaction search params', () => {
+    const sender = 'I3345FUQQ2GRBHFZQPLYQQX5HJMMRZMABCHRLWV6RCJYC6OO4MOLEUBEGU'
+    const receiver = 'AAOLENX3Z76HBMQOLQF4VW26ZQSORVX7ZQJ66LCPX36T2QNAUYOYEY76RM'
+    const amount = 2_500_000
+    const fee = 3_000_000
+    const note = 'Some payment notes'
+
+    it('should render payment transaction with minimal required fields only', () => {
+      renderTxnsWizardPageWithSearchParams({
+        searchParams: new URLSearchParams({
+          'type[0]': 'pay',
+          'sender[0]': sender,
+          'receiver[0]': receiver,
+          'amount[0]': amount.toString(),
+        }),
+      })
+
+      expect(screen.getByText(sender)).toBeInTheDocument()
+      expect(screen.getByText(receiver)).toBeInTheDocument()
+      expect(screen.getByText('2.5')).toBeInTheDocument()
+    })
+
+    it('should render payment transaction with all optional fields', () => {
+      renderTxnsWizardPageWithSearchParams({
+        searchParams: new URLSearchParams({
+          'type[0]': 'pay',
+          'sender[0]': sender,
+          'receiver[0]': receiver,
+          'amount[0]': amount.toString(),
+          'fee[0]': fee.toString(),
+          'note[0]': note,
+        }),
+      })
+      expect(screen.getByText(sender)).toBeInTheDocument()
+      expect(screen.getByText(receiver)).toBeInTheDocument()
+      expect(screen.getByText('2.5')).toBeInTheDocument()
+      expect(screen.getByText('3')).toBeInTheDocument()
+      expect(screen.getByText(note)).toBeInTheDocument()
+    })
+
+    it('should render payment transaction with fee only', () => {
+      renderTxnsWizardPageWithSearchParams({
+        searchParams: new URLSearchParams({
+          'type[0]': 'pay',
+          'sender[0]': sender,
+          'receiver[0]': receiver,
+          'amount[0]': amount.toString(),
+          'fee[0]': fee.toString(),
+        }),
+      })
+      expect(screen.getByText(sender)).toBeInTheDocument()
+      expect(screen.getByText(receiver)).toBeInTheDocument()
+      expect(screen.getByText('2.5')).toBeInTheDocument()
+      expect(screen.getByText('3')).toBeInTheDocument()
+    })
+
+    it('should render payment transaction with note only', () => {
+      renderTxnsWizardPageWithSearchParams({
+        searchParams: new URLSearchParams({
+          'type[0]': 'pay',
+          'sender[0]': sender,
+          'receiver[0]': receiver,
+          'amount[0]': amount.toString(),
+          'note[0]': note,
+        }),
+      })
+      expect(screen.getByText(sender)).toBeInTheDocument()
+      expect(screen.getByText(receiver)).toBeInTheDocument()
+      expect(screen.getByText('2.5')).toBeInTheDocument()
+      expect(screen.getByText(note)).toBeInTheDocument()
+    })
+
+    it.each([
+      // Missing required field cases
+      {
+        key: 'sender[0]',
+        mode: 'missing',
+        expected: 'Error in transaction at index 0 in the following fields: sender-value, sender-resolvedAddress',
+      },
+      {
+        key: 'receiver[0]',
+        mode: 'missing',
+        expected: 'Error in transaction at index 0 in the following fields: receiver-value, receiver-resolvedAddress',
+      },
+      {
+        key: 'amount[0]',
+        mode: 'missing',
+        expected: 'Error in transaction at index 0: The number NaN cannot be converted to a BigInt because it is not an integer',
+      },
+      // Invalid field value cases
+      {
+        key: 'sender[0]',
+        mode: 'invalid',
+        value: 'invalid-address',
+        expected: 'Error in transaction at index 0 in the following fields: sender-value, sender-value',
+      },
+      {
+        key: 'receiver[0]',
+        mode: 'invalid',
+        value: 'invalid-address',
+        expected: 'Error in transaction at index 0 in the following fields: receiver-value, receiver-value',
+      },
+      {
+        key: 'amount[0]',
+        mode: 'invalid',
+        value: 'not-a-number',
+        expected: 'Error in transaction at index 0: The number NaN cannot be converted to a BigInt because it is not an integer',
+      },
+      {
+        key: 'amount[0]',
+        mode: 'invalid',
+        value: '-100',
+        expected: 'Error in transaction at index 0: Microalgos should be positive and less than 2^53 - 1.',
+      },
+      {
+        key: 'fee[0]',
+        mode: 'invalid',
+        value: 'not-a-number',
+        expected: 'Error in transaction at index 0: The number NaN cannot be converted to a BigInt because it is not an integer',
+      },
+      {
+        key: 'fee[0]',
+        mode: 'invalid',
+        value: '-100',
+        expected: 'Error in transaction at index 0: Microalgos should be positive and less than 2^53 - 1.',
+      },
+    ])('should show error toast for $mode $key', async ({ key, mode, value, expected }) => {
+      const baseParams: Record<string, string> = {
+        'type[0]': 'pay',
+        'sender[0]': sender,
+        'receiver[0]': receiver,
+        'amount[0]': amount.toString(),
+      }
+      if (mode === 'missing') {
+        delete baseParams[key]
+      } else if (mode === 'invalid' && value !== undefined) {
+        baseParams[key] = value.toString()
+      }
+      const searchParams = new URLSearchParams(baseParams)
+      renderTxnsWizardPageWithSearchParams({ searchParams })
+      const toastElement = await screen.findByText(expected)
+      expect(toastElement).toBeInTheDocument()
+      cleanup()
     })
   })
 })

--- a/src/features/transaction-wizard/utils/transactions-url-search-params.test.tsx
+++ b/src/features/transaction-wizard/utils/transactions-url-search-params.test.tsx
@@ -330,29 +330,6 @@ describe('Render transactions page with search params', () => {
       expect(screen.getByText(note)).toBeInTheDocument()
     })
 
-    it('should render asset create transaction with kebab-case parameter names', () => {
-      renderTxnsWizardPageWithSearchParams({
-        searchParams: new URLSearchParams({
-          'type[0]': 'acfg',
-          'sender[0]': sender,
-          'total[0]': total,
-          'decimals[0]': decimals,
-          'asset-name[0]': assetName,
-          'unit-name[0]': unitName,
-          'metadata-hash[0]': metadataHash,
-          'default-frozen[0]': 'true',
-        }),
-      })
-
-      expect(screen.getByText(sender)).toBeInTheDocument()
-      expect(screen.getByText('1000000')).toBeInTheDocument()
-      expect(screen.getByText(decimals)).toBeInTheDocument()
-      expect(screen.getByText(assetName)).toBeInTheDocument()
-      expect(screen.getByText(unitName)).toBeInTheDocument()
-      expect(screen.getByText(metadataHash)).toBeInTheDocument()
-      expect(screen.getByText('true')).toBeInTheDocument()
-    })
-
     it('should render asset create transaction with fee only', () => {
       renderTxnsWizardPageWithSearchParams({
         searchParams: new URLSearchParams({

--- a/src/features/transaction-wizard/utils/transactions-url-search-params.test.tsx
+++ b/src/features/transaction-wizard/utils/transactions-url-search-params.test.tsx
@@ -264,4 +264,236 @@ describe('Render transactions page with search params', () => {
       cleanup()
     })
   })
+
+  describe('asset create transaction search params', () => {
+    const sender = 'I3345FUQQ2GRBHFZQPLYQQX5HJMMRZMABCHRLWV6RCJYC6OO4MOLEUBEGU'
+    const total = '1000000'
+    const decimals = '2'
+    const assetName = 'TestCoin'
+    const unitName = 'TC'
+    const url = 'https://example.com/asset.json'
+    const metadataHash = 'SGVsbG8gV29ybGQ='
+    const manager = 'AAOLENX3Z76HBMQOLQF4VW26ZQSORVX7ZQJ66LCPX36T2QNAUYOYEY76RM'
+    const reserve = 'DJ76C74DI7EDNSHQLAJXGMBHFINBLATVGNRAVCO3VILPCQR7LKY7GPUL7Y'
+    const freeze = 'UJSXVS7TLTNFZF4PDRYDQI4IGMZNF7S4PO2F7ZNX372UWFJMNT4ZJ7RAEI'
+    const clawback = 'U6S57IUI3EJIIKPGGGKGD5C6S2VCJQ3SBWDDWUO4LNI7QL5AA3LTZKEWZM'
+    const fee = '2000'
+    const note = 'Asset creation test'
+
+    it('should render asset create transaction with minimal required fields only', () => {
+      renderTxnsWizardPageWithSearchParams({
+        searchParams: new URLSearchParams({
+          'type[0]': 'acfg',
+          'sender[0]': sender,
+          'total[0]': total,
+          'decimals[0]': decimals,
+        }),
+      })
+
+      expect(screen.getByText(sender)).toBeInTheDocument()
+      expect(screen.getByText('1000000')).toBeInTheDocument()
+      expect(screen.getByText(decimals)).toBeInTheDocument()
+    })
+
+    it('should render asset create transaction with all optional fields', () => {
+      renderTxnsWizardPageWithSearchParams({
+        searchParams: new URLSearchParams({
+          'type[0]': 'acfg',
+          'sender[0]': sender,
+          'total[0]': total,
+          'decimals[0]': decimals,
+          'assetname[0]': assetName,
+          'unitname[0]': unitName,
+          'url[0]': url,
+          'metadatahash[0]': metadataHash,
+          'defaultfrozen[0]': 'false',
+          'manager[0]': manager,
+          'reserve[0]': reserve,
+          'freeze[0]': freeze,
+          'clawback[0]': clawback,
+          'fee[0]': fee,
+          'note[0]': note,
+        }),
+      })
+
+      expect(screen.getByText(sender)).toBeInTheDocument()
+      expect(screen.getByText('1000000')).toBeInTheDocument()
+      expect(screen.getByText(decimals)).toBeInTheDocument()
+      expect(screen.getByText(assetName)).toBeInTheDocument()
+      expect(screen.getByText(unitName)).toBeInTheDocument()
+      expect(screen.getByText(url)).toBeInTheDocument()
+      expect(screen.getByText(manager)).toBeInTheDocument()
+      expect(screen.getByText(reserve)).toBeInTheDocument()
+      expect(screen.getByText(freeze)).toBeInTheDocument()
+      expect(screen.getByText(clawback)).toBeInTheDocument()
+      expect(screen.getByText('0.002')).toBeInTheDocument()
+      expect(screen.getByText(note)).toBeInTheDocument()
+    })
+
+    it('should render asset create transaction with kebab-case parameter names', () => {
+      renderTxnsWizardPageWithSearchParams({
+        searchParams: new URLSearchParams({
+          'type[0]': 'acfg',
+          'sender[0]': sender,
+          'total[0]': total,
+          'decimals[0]': decimals,
+          'asset-name[0]': assetName,
+          'unit-name[0]': unitName,
+          'metadata-hash[0]': metadataHash,
+          'default-frozen[0]': 'true',
+        }),
+      })
+
+      expect(screen.getByText(sender)).toBeInTheDocument()
+      expect(screen.getByText('1000000')).toBeInTheDocument()
+      expect(screen.getByText(decimals)).toBeInTheDocument()
+      expect(screen.getByText(assetName)).toBeInTheDocument()
+      expect(screen.getByText(unitName)).toBeInTheDocument()
+      expect(screen.getByText(metadataHash)).toBeInTheDocument()
+      expect(screen.getByText('true')).toBeInTheDocument()
+    })
+
+    it('should render asset create transaction with fee only', () => {
+      renderTxnsWizardPageWithSearchParams({
+        searchParams: new URLSearchParams({
+          'type[0]': 'acfg',
+          'sender[0]': sender,
+          'total[0]': total,
+          'decimals[0]': decimals,
+          'fee[0]': fee,
+        }),
+      })
+
+      expect(screen.getByText(sender)).toBeInTheDocument()
+      expect(screen.getByText('1000000')).toBeInTheDocument()
+      expect(screen.getByText(decimals)).toBeInTheDocument()
+      expect(screen.getByText('0.002')).toBeInTheDocument()
+    })
+
+    it('should render asset create transaction with note only', () => {
+      renderTxnsWizardPageWithSearchParams({
+        searchParams: new URLSearchParams({
+          'type[0]': 'acfg',
+          'sender[0]': sender,
+          'total[0]': total,
+          'decimals[0]': decimals,
+          'note[0]': note,
+        }),
+      })
+
+      expect(screen.getByText(sender)).toBeInTheDocument()
+      expect(screen.getByText('1000000')).toBeInTheDocument()
+      expect(screen.getByText(decimals)).toBeInTheDocument()
+      expect(screen.getByText(note)).toBeInTheDocument()
+    })
+
+    it.each([
+      // Missing required field cases
+      {
+        key: 'sender[0]',
+        mode: 'missing',
+        expected: 'Error in transaction at index 0 in the following fields: sender-value, sender-resolvedAddress',
+      },
+      {
+        key: 'total[0]',
+        mode: 'missing',
+        expected: 'Error in transaction at index 0: Cannot convert undefined to a BigInt',
+      },
+      {
+        key: 'decimals[0]',
+        mode: 'missing',
+        expected: 'Error in transaction at index 0 in the following fields: decimals',
+      },
+      // Invalid field value cases
+      {
+        key: 'sender[0]',
+        mode: 'invalid',
+        value: 'invalid-address',
+        expected: 'Error in transaction at index 0 in the following fields: sender-value, sender-value',
+      },
+      {
+        key: 'total[0]',
+        mode: 'invalid',
+        value: 'not-a-number',
+        expected: 'Error in transaction at index 0: Cannot convert not-a-number to a BigInt',
+      },
+      {
+        key: 'total[0]',
+        mode: 'invalid',
+        value: '-100',
+        expected: 'Error in transaction at index 0 in the following fields: total',
+      },
+      {
+        key: 'decimals[0]',
+        mode: 'invalid',
+        value: 'not-a-number',
+        expected: 'Error in transaction at index 0 in the following fields: decimals',
+      },
+      {
+        key: 'decimals[0]',
+        mode: 'invalid',
+        value: '-1',
+        expected: 'Error in transaction at index 0 in the following fields: decimals',
+      },
+      {
+        key: 'decimals[0]',
+        mode: 'invalid',
+        value: '20',
+        expected: 'Error in transaction at index 0 in the following fields: decimals',
+      },
+      {
+        key: 'manager[0]',
+        mode: 'invalid',
+        value: 'invalid-address',
+        expected: 'Error in transaction at index 0 in the following fields: manager-value, manager-value',
+      },
+      {
+        key: 'reserve[0]',
+        mode: 'invalid',
+        value: 'invalid-address',
+        expected: 'Error in transaction at index 0 in the following fields: reserve-value, reserve-value',
+      },
+      {
+        key: 'freeze[0]',
+        mode: 'invalid',
+        value: 'invalid-address',
+        expected: 'Error in transaction at index 0 in the following fields: freeze-value, freeze-value',
+      },
+      {
+        key: 'clawback[0]',
+        mode: 'invalid',
+        value: 'invalid-address',
+        expected: 'Error in transaction at index 0 in the following fields: clawback-value, clawback-value',
+      },
+      {
+        key: 'fee[0]',
+        mode: 'invalid',
+        value: 'not-a-number',
+        expected: 'Error in transaction at index 0: The number NaN cannot be converted to a BigInt because it is not an integer',
+      },
+      {
+        key: 'fee[0]',
+        mode: 'invalid',
+        value: '-100',
+        expected: 'Error in transaction at index 0: Microalgos should be positive and less than 2^53 - 1.',
+      },
+    ])('should show error toast for $mode $key', async ({ key, mode, value, expected }) => {
+      const baseParams: Record<string, string> = {
+        'type[0]': 'acfg',
+        'sender[0]': sender,
+        'total[0]': total,
+        'decimals[0]': decimals,
+      }
+      if (mode === 'missing') {
+        delete baseParams[key]
+      } else if (mode === 'invalid' && value !== undefined) {
+        baseParams[key] = value.toString()
+      }
+      const searchParams = new URLSearchParams(baseParams)
+      renderTxnsWizardPageWithSearchParams({ searchParams })
+      const toastElement = await screen.findByText(expected)
+      expect(toastElement).toBeInTheDocument()
+      cleanup()
+    })
+  })
 })

--- a/src/features/transaction-wizard/utils/transform-search-params-transactions.ts
+++ b/src/features/transaction-wizard/utils/transform-search-params-transactions.ts
@@ -60,7 +60,7 @@ const transformPaymentTransaction = (params: BaseSearchParamTransaction): BuildP
     firstValid: undefined,
     lastValid: undefined,
   },
-  note: params.note ? params.note : undefined,
+  note: params.note,
 })
 
 const defaultOptionalAddress = {
@@ -76,11 +76,11 @@ const transformAssetCreateTransaction = (params: BaseSearchParamTransaction): Bu
   },
   total: BigInt(params.total),
   decimals: Number(params.decimals),
-  assetName: params.assetname || params['asset-name'],
-  unitName: params.unitname || params['unit-name'],
+  assetName: params.assetname,
+  unitName: params.unitname,
   url: params.url,
-  metadataHash: params.metadatahash || params['metadata-hash'],
-  defaultFrozen: Boolean(params.defaultfrozen || params['default-frozen']),
+  metadataHash: params.metadatahash,
+  defaultFrozen: params.defaultfrozen === 'true',
   manager: params.manager
     ? {
         value: params.manager,

--- a/src/features/transaction-wizard/utils/transform-search-params-transactions.ts
+++ b/src/features/transaction-wizard/utils/transform-search-params-transactions.ts
@@ -74,8 +74,8 @@ const transformAssetCreateTransaction = (params: BaseSearchParamTransaction): Bu
     value: params.sender,
     resolvedAddress: params.sender,
   },
-  total: BigInt(params.total || '1'),
-  decimals: Number(params.decimals || '0'),
+  total: BigInt(params.total),
+  decimals: Number(params.decimals),
   assetName: params.assetname || params['asset-name'],
   unitName: params.unitname || params['unit-name'],
   url: params.url,
@@ -145,7 +145,6 @@ export function transformSearchParamsTransactions(searchParamTransactions: BaseS
       transactionsFromSearchParams.push(transaction)
     } catch (error) {
       if (error instanceof z.ZodError) {
-        console.log({ error })
         const badPaths = error.errors.map((e) => e.path.join('-'))
         errors.push(`Error in transaction at index ${index} in the following fields: ${badPaths.join(', ')}`)
         continue

--- a/src/features/transaction-wizard/utils/transform-search-params-transactions.ts
+++ b/src/features/transaction-wizard/utils/transform-search-params-transactions.ts
@@ -51,7 +51,7 @@ const transformPaymentTransaction = (params: BaseSearchParamTransaction): BuildP
     value: params.receiver,
     resolvedAddress: params.receiver,
   },
-  amount: microAlgo(Number(params.amount ?? 0)).algo,
+  amount: microAlgo(Number(params.amount)).algo,
   fee: params.fee ? { setAutomatically: false, value: microAlgo(Number(params.fee)).algo } : { setAutomatically: true },
   validRounds: {
     setAutomatically: true,

--- a/src/features/transaction-wizard/utils/transform-search-params-transactions.ts
+++ b/src/features/transaction-wizard/utils/transform-search-params-transactions.ts
@@ -2,9 +2,11 @@ import {
   BaseSearchParamTransaction,
   BuildableTransactionType,
   BuildKeyRegistrationTransactionResult,
+  BuildPaymentTransactionResult,
   BuildTransactionResult,
 } from '../models'
 import { keyRegistrationFormSchema } from '../components/key-registration-transaction-builder'
+import { paymentFormSchema } from '../components/payment-transaction-builder'
 import { z } from 'zod'
 import { randomGuid } from '@/utils/random-guid'
 import algosdk from 'algosdk'
@@ -38,17 +40,52 @@ const transformKeyRegistrationTransaction = (params: BaseSearchParamTransaction)
   },
 })
 
+const transformPaymentTransaction = (params: BaseSearchParamTransaction): BuildPaymentTransactionResult => ({
+  id: randomGuid(),
+  type: BuildableTransactionType.Payment,
+  sender: {
+    value: params.sender,
+    resolvedAddress: params.sender,
+  },
+  receiver: {
+    value: params.receiver,
+    resolvedAddress: params.receiver,
+  },
+  amount: microAlgo(Number(params.amount ?? 0)).algo,
+  fee: params.fee ? { setAutomatically: false, value: microAlgo(Number(params.fee)).algo } : { setAutomatically: true },
+  validRounds: {
+    setAutomatically: true,
+    firstValid: undefined,
+    lastValid: undefined,
+  },
+  note: params.note ? params.note : undefined,
+})
+
+const transformationConfigByTransactionType = {
+  [algosdk.TransactionType.keyreg]: {
+    transform: transformKeyRegistrationTransaction,
+    schema: keyRegFormSchema,
+  },
+  [algosdk.TransactionType.pay]: {
+    transform: transformPaymentTransaction,
+    schema: paymentFormSchema,
+  },
+  // TODO: Add other transaction types
+}
+
 export function transformSearchParamsTransactions(searchParamTransactions: BaseSearchParamTransaction[]) {
   const transactionsFromSearchParams: BuildTransactionResult[] = []
   const errors: string[] = []
   for (const [index, searchParamTransaction] of searchParamTransactions.entries()) {
+    if (!(searchParamTransaction.type in transformationConfigByTransactionType)) {
+      continue // Skip transactions with unsupported types
+    }
+    const { transform, schema } =
+      transformationConfigByTransactionType[searchParamTransaction.type as keyof typeof transformationConfigByTransactionType]
     try {
-      if (searchParamTransaction.type === algosdk.TransactionType.keyreg) {
-        const keyRegTransaction = transformKeyRegistrationTransaction(searchParamTransaction)
-        keyRegFormSchema.parse(keyRegTransaction)
-        transactionsFromSearchParams.push(keyRegTransaction)
-      }
-      // TODO: Add other transaction types
+      const transaction = transform(searchParamTransaction)
+      schema.parse(transaction)
+      transactionsFromSearchParams.push(transaction)
     } catch (error) {
       if (error instanceof z.ZodError) {
         const badPaths = error.errors.map((e) => e.path.join('-'))


### PR DESCRIPTION
Added Payment and asset create transaction to search params

**Commit 1** 
Added the core infrastructure for payment transaction URL search params. Built useTransactionSearchParamsBuilder hook that parses URL parameters like type[0]=pay&sender[0]=ADDRESS&amount[0]=1000000 and transforms them into transaction objects that automatically populate the wizard forms.

Test params
minimal payment
https://db31f5ca.algokit-lora.pages.dev/mainnet/transaction-wizard?type[0]=pay&sender[0]=I3345FUQQ2GRBHFZQPLYQQX5HJMMRZMABCHRLWV6RCJYC6OO4MOLEUBEGU&receiver[0]=AAOLENX3Z76HBMQOLQF4VW26ZQSORVX7ZQJ66LCPX36T2QNAUYOYEY76RM&amount[0]=2500000

full payment
https://db31f5ca.algokit-lora.pages.dev/mainnet/transaction-wizard?type[0]=pay&sender[0]=I3345FUQQ2GRBHFZQPLYQQX5HJMMRZMABCHRLWV6RCJYC6OO4MOLEUBEGU&receiver[0]=AAOLENX3Z76HBMQOLQF4VW26ZQSORVX7ZQJ66LCPX36T2QNAUYOYEY76RM&amount[0]=2500000&fee[0]=3000000&note[0]=Test%20payment%20with%20custom%20fee

**Commit 2** 
Added comprehensive test coverage for payment transactions, testing both minimal required fields and full optional field combinations, plus proper error handling for invalid/missing parameters with toast notifications.

**Commit 3** 
Extended URL search params support to asset creation transactions, handling all asset fields including manager/reserve/freeze/clawback addresses. Supports both camelCase and kebab-case parameter naming conventions.

**minimal asset create**
https://db31f5ca.algokit-lora.pages.dev/mainnet/transaction-wizard?type[0]=acfg&sender[0]=I3345FUQQ2GRBHFZQPLYQQX5HJMMRZMABCHRLWV6RCJYC6OO4MOLEUBEGU&total[0]=1000000&decimals[0]=2

**full asset create**
https://db31f5ca.algokit-lora.pages.dev/mainnet/transaction-wizard?type[0]=acfg&sender[0]=I3345FUQQ2GRBHFZQPLYQQX5HJMMRZMABCHRLWV6RCJYC6OO4MOLEUBEGU&total[0]=1000000&decimals[0]=2&assetname[0]=TestCoin&unitname[0]=TC&url[0]=https://example.com/asset.json&manager[0]=AAOLENX3Z76HBMQOLQF4VW26ZQSORVX7ZQJ66LCPX36T2QNAUYOYEY76RM&reserve[0]=DJ76C74DI7EDNSHQLAJXGMBHFINBLATVGNRAVCO3VILPCQR7LKY7GPUL7Y&fee[0]=2000&note[0]=Asset%20creation%20test

**Commit 4** 
Added extensive test coverage for asset creation transactions, but during testing discovered validation errors in the current asset create transaction implementation that needed to be fixed. The tests cover minimal vs full field sets, parameter name variations, and comprehensive error scenarios.