### PR TITLE
fix: patch algosdk so deleted applications can be fetched

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@txnlab/use-wallet": "^4.0.0",
         "@txnlab/use-wallet-react": "^4.0.0",
         "@xstate/react": "^5.0.3",
-        "algosdk": "3.1.0",
+        "algosdk": "3.3.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "cmdk": "^1.0.0",
@@ -5084,9 +5084,10 @@
       }
     },
     "node_modules/algosdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-3.1.0.tgz",
-      "integrity": "sha512-0mT+GKG5jmMyCVl0cj4uwvnPBnMwW1FCwCpsMk1n0tXPyb7deCGuCq1HlHtk6nf3sjE6te83BtfkOvIrdSTMXg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-3.3.1.tgz",
+      "integrity": "sha512-HhECqY3SIqXTl7qNS7pFR+raOU7OPaJlTQBB8JWPA4F2N2OmUHYu9IDHeN+nu6Sb2uDlFJVB/tWYSc17zCNUoQ==",
+      "license": "MIT",
       "dependencies": {
         "algorand-msgpack": "^1.1.0",
         "hi-base32": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@txnlab/use-wallet": "^4.0.0",
     "@txnlab/use-wallet-react": "^4.0.0",
     "@xstate/react": "^5.0.3",
-    "algosdk": "3.1.0",
+    "algosdk": "3.3.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "cmdk": "^1.0.0",

--- a/patches/algosdk+3.3.1.patch
+++ b/patches/algosdk+3.3.1.patch
@@ -1,0 +1,42 @@
+diff --git a/node_modules/algosdk/dist/cjs/encoding/schema/bytearray.js b/node_modules/algosdk/dist/cjs/encoding/schema/bytearray.js
+index 99f77ca..15fb232 100644
+--- a/node_modules/algosdk/dist/cjs/encoding/schema/bytearray.js
++++ b/node_modules/algosdk/dist/cjs/encoding/schema/bytearray.js
+@@ -34,6 +34,9 @@ class ByteArraySchema extends encoding_js_1.Schema {
+         throw new Error(`Invalid byte array: (${typeof data}) ${data}`);
+     }
+     fromPreparedJSON(encoded) {
++        if (encoded === null || encoded === undefined) {
++          return new Uint8Array();
++        }
+         if (typeof encoded === 'string') {
+             return (0, binarydata_js_1.base64ToBytes)(encoded);
+         }
+diff --git a/node_modules/algosdk/dist/esm/encoding/schema/bytearray.js b/node_modules/algosdk/dist/esm/encoding/schema/bytearray.js
+index d9ed6fa..5bd9eb5 100644
+--- a/node_modules/algosdk/dist/esm/encoding/schema/bytearray.js
++++ b/node_modules/algosdk/dist/esm/encoding/schema/bytearray.js
+@@ -31,6 +31,9 @@ export class ByteArraySchema extends Schema {
+         throw new Error(`Invalid byte array: (${typeof data}) ${data}`);
+     }
+     fromPreparedJSON(encoded) {
++        if (encoded === null || encoded === undefined) {
++          return new Uint8Array();
++        }
+         if (typeof encoded === 'string') {
+             return base64ToBytes(encoded);
+         }
+diff --git a/node_modules/algosdk/src/encoding/schema/bytearray.ts b/node_modules/algosdk/src/encoding/schema/bytearray.ts
+index 5218049..6648087 100644
+--- a/node_modules/algosdk/src/encoding/schema/bytearray.ts
++++ b/node_modules/algosdk/src/encoding/schema/bytearray.ts
+@@ -48,6 +48,9 @@ export class ByteArraySchema extends Schema {
+   }
+ 
+   public fromPreparedJSON(encoded: JSONEncodingData): Uint8Array {
++    if (encoded === null || encoded === undefined) {
++      return new Uint8Array();
++    }
+     if (typeof encoded === 'string') {
+       return base64ToBytes(encoded);
+     }


### PR DESCRIPTION
Fixes https://github.com/algorandfoundation/algokit-lora/issues/455

When trying to load an application that has been deleted, the following error is returned "Error: Application failed to load". This is due to the algosdk@3 indexer client not handling the null approval and clear program which is returned when the application is deleted.

This PR monkey patches algosdk to convert any null or undefined bytes value it encounters when deserialising JSON into empty bytes value.

An upstream PR to algosdk has been created https://github.com/algorand/js-algorand-sdk/pull/991