### PR TITLE
feat: render payment txn with close remainder

### DIFF
--- a/src/features/transactions/components/transactions-table-columns.tsx
+++ b/src/features/transactions/components/transactions-table-columns.tsx
@@ -106,7 +106,7 @@ const toColumn: ColumnDef<Transaction | InnerTransaction> = {
   accessorFn: (transaction) => transaction,
   cell: (c) => {
     const transaction = c.getValue<Transaction>()
-    if (transaction.type === TransactionType.Payment && transaction.subType === PaymentTransactionSubType.AccountClose) {
+    if (transaction.subType === PaymentTransactionSubType.AccountClose) {
       return (
         <div className="grid gap-1">
           <AccountLink address={transaction.receiver} short={true} />

--- a/src/features/transactions/components/transactions-table-columns.tsx
+++ b/src/features/transactions/components/transactions-table-columns.tsx
@@ -1,4 +1,10 @@
-import { AssetTransferTransactionSubType, InnerTransaction, Transaction, TransactionType } from '@/features/transactions/models'
+import {
+  AssetTransferTransactionSubType,
+  InnerTransaction,
+  PaymentTransactionSubType,
+  Transaction,
+  TransactionType,
+} from '@/features/transactions/models'
 import { cn } from '@/features/common/utils'
 import { ColumnDef } from '@tanstack/react-table'
 import { DisplayAlgo } from '@/features/common/components/display-algo'
@@ -21,8 +27,6 @@ export const transactionAmountLabel = 'Amount'
 export const transactionRoundLabel = 'Round'
 export const transactionTimestampLabel = 'Timestamp'
 export const transactionFeeLabel = 'Fee'
-
-const isAccountCloseTransaction = (txn: Transaction | InnerTransaction) => txn.type === TransactionType.Payment && txn.closeRemainder
 
 const expandColumn: ColumnDef<Transaction | InnerTransaction> = {
   id: 'expand',
@@ -102,19 +106,15 @@ const toColumn: ColumnDef<Transaction | InnerTransaction> = {
   accessorFn: (transaction) => transaction,
   cell: (c) => {
     const transaction = c.getValue<Transaction>()
-    if (transaction.type === TransactionType.Payment && transaction.closeRemainder) {
+    if (transaction.type === TransactionType.Payment && transaction.subType === PaymentTransactionSubType.AccountClose) {
       return (
-        <div className="grid gap-2">
+        <div className="grid gap-1">
           <AccountLink address={transaction.receiver} short={true} />
           <AccountLink address={transaction.closeRemainder.to} short={true} />
         </div>
       )
     }
-    return (
-      <div className={cn(isAccountCloseTransaction(transaction) ? 'grid' : '')}>
-        <TransactionTo transaction={c.getValue<Transaction>()} />
-      </div>
-    )
+    return <TransactionTo transaction={c.getValue<Transaction>()} />
   },
   meta: { className: 'max-w-36 align-top' },
 }
@@ -130,25 +130,17 @@ const amountColumn: ColumnDef<Transaction | InnerTransaction> = {
   cell: (c) => {
     const transaction = c.getValue<Transaction>()
     if (transaction.type === TransactionType.Payment) {
-      if (transaction.closeRemainder) {
+      if (transaction.subType === PaymentTransactionSubType.AccountClose) {
         return (
-          <div className="grid gap-2">
+          <div className="grid gap-1">
             <DisplayAlgo amount={transaction.amount} />
             <DisplayAlgo amount={transaction.closeRemainder.amount} />
           </div>
         )
       }
-      return (
-        <div className={cn(isAccountCloseTransaction(transaction) ? 'grid' : '')}>
-          <DisplayAlgo amount={transaction.amount} />
-        </div>
-      )
+      return <DisplayAlgo amount={transaction.amount} />
     } else if (transaction.type === TransactionType.AssetTransfer) {
-      return (
-        <div className={cn(isAccountCloseTransaction(transaction) ? 'grid' : '')}>
-          <DisplayAssetAmount amount={transaction.amount} asset={transaction.asset} />
-        </div>
-      )
+      return <DisplayAssetAmount amount={transaction.amount} asset={transaction.asset} />
     }
   },
   meta: { className: 'align-top' },

--- a/src/features/transactions/mappers/payment-transaction-mappers.ts
+++ b/src/features/transactions/mappers/payment-transaction-mappers.ts
@@ -1,4 +1,4 @@
-import { BasePaymentTransaction, InnerPaymentTransaction, PaymentTransaction, TransactionType } from '../models'
+import { BasePaymentTransaction, InnerPaymentTransaction, PaymentTransaction, PaymentTransactionSubType, TransactionType } from '../models'
 import { invariant } from '@/utils/invariant'
 import { asInnerTransactionId, mapCommonTransactionProperties } from './transaction-common-properties-mappers'
 import { microAlgos } from '@algorandfoundation/algokit-utils'
@@ -11,15 +11,20 @@ const mapCommonPaymentTransactionProperties = (transactionResult: TransactionRes
   return {
     ...mapCommonTransactionProperties(transactionResult),
     type: TransactionType.Payment,
-    subType: undefined,
     receiver: payment.receiver,
     amount: microAlgos(payment.amount),
-    closeRemainder: payment.closeRemainderTo
+    ...(payment.closeRemainderTo
       ? {
-          to: payment.closeRemainderTo,
-          amount: microAlgos(payment.closeAmount ?? 0n),
+          subType: PaymentTransactionSubType.AccountClose,
+          closeRemainder: {
+            to: payment.closeRemainderTo,
+            amount: microAlgos(payment.closeAmount ?? 0n),
+          },
         }
-      : undefined,
+      : {
+          subType: undefined,
+          closeRemainder: undefined,
+        }),
   } satisfies BasePaymentTransaction
 }
 

--- a/src/features/transactions/models/index.ts
+++ b/src/features/transactions/models/index.ts
@@ -40,7 +40,7 @@ export enum AssetTransferTransactionSubType {
 }
 
 export enum PaymentTransactionSubType {
-  AccountClose = 'Account-Close',
+  AccountClose = 'Account Close',
 }
 
 export type CloseAlgoRemainder = {

--- a/src/features/transactions/models/index.ts
+++ b/src/features/transactions/models/index.ts
@@ -39,6 +39,10 @@ export enum AssetTransferTransactionSubType {
   OptOut = 'Opt-out',
 }
 
+export enum PaymentTransactionSubType {
+  AccountClose = 'Account-Close',
+}
+
 export type CloseAlgoRemainder = {
   to: Address
   amount: AlgoAmount
@@ -51,11 +55,18 @@ export type CloseAssetRemainder = {
 
 export type BasePaymentTransaction = CommonTransactionProperties & {
   type: TransactionType.Payment
-  subType: undefined
   receiver: Address
   amount: AlgoAmount
-  closeRemainder?: CloseAlgoRemainder
-}
+} & (
+    | {
+        subType: undefined
+        closeRemainder: undefined
+      }
+    | {
+        subType: PaymentTransactionSubType.AccountClose
+        closeRemainder: CloseAlgoRemainder
+      }
+  )
 
 export type PaymentTransaction = BasePaymentTransaction & {
   id: string

--- a/src/features/transactions/pages/transaction-page.test.tsx
+++ b/src/features/transactions/pages/transaction-page.test.tsx
@@ -189,7 +189,7 @@ describe('transaction-page', () => {
               container: component.container,
               items: [
                 { term: transactionIdLabel, description: transaction.id },
-                { term: transactionTypeLabel, description: 'PaymentAccount-Close' },
+                { term: transactionTypeLabel, description: 'PaymentAccount Close' },
                 { term: transactionTimestampLabel, description: 'Thu, 29 February 2024 06:52:01' },
                 { term: transactionBlockLabel, description: '36570178' },
                 { term: transactionFeeLabel, description: '0.001' },

--- a/src/features/transactions/pages/transaction-page.test.tsx
+++ b/src/features/transactions/pages/transaction-page.test.tsx
@@ -220,7 +220,7 @@ describe('transaction-page', () => {
             container: tableViewTab,
             rows: [
               {
-                cells: ['', 'FBORGSD…', '', 'M3IA…OXXM', 'KIZL…U5BQ', 'Payment', '236.07'],
+                cells: ['', 'FBORGSD…', '', 'M3IA…OXXM', 'KIZL…U5BQAIZL…U5BQ', 'Payment', '236.07345.071234'],
               },
             ],
           })

--- a/src/features/transactions/pages/transaction-page.test.tsx
+++ b/src/features/transactions/pages/transaction-page.test.tsx
@@ -189,7 +189,7 @@ describe('transaction-page', () => {
               container: component.container,
               items: [
                 { term: transactionIdLabel, description: transaction.id },
-                { term: transactionTypeLabel, description: 'Payment' },
+                { term: transactionTypeLabel, description: 'PaymentAccount-Close' },
                 { term: transactionTimestampLabel, description: 'Thu, 29 February 2024 06:52:01' },
                 { term: transactionBlockLabel, description: '36570178' },
                 { term: transactionFeeLabel, description: '0.001' },


### PR DESCRIPTION
Update the transaction table columns logic to render payment txn with close remainder. After this change, the close remainder to and amount fields are rendered on the transaction table.
![image](https://github.com/user-attachments/assets/261217f5-7799-4e67-b38e-f1aedb9528f3)
