### PR TITLE
fix: added secrets to workflow_call workflows

### DIFF
--- a/.github/workflows/release-desktop.yaml
+++ b/.github/workflows/release-desktop.yaml
@@ -31,6 +31,35 @@ on:
         description: 'CrabNebula release ID'
         required: true
         type: string
+    secrets:
+      BOT_ID:
+        required: true
+      BOT_SK:
+        required: true
+      APPLE_CERTIFICATE:
+        required: true
+      APPLE_CERTIFICATE_PASSWORD:
+        required: true
+      APPLE_ID:
+        required: true
+      APPLE_PASSWORD:
+        required: true
+      APPLE_TEAM_ID:
+        required: true
+      KEYCHAIN_PASSWORD:
+        required: true
+      TAURI_SIGNING_PRIVATE_KEY:
+        required: true
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD:
+        required: true
+      TAURI_SIGNING_PUBLIC_KEY:
+        required: true
+      CRABNEBULA_ORG_NAME:
+        required: true
+      CRABNEBULA_APP_NAME:
+        required: true
+      CRABNEBULA_API_KEY:
+        required: true
 
 concurrency: build-desktop
 

--- a/.github/workflows/release-web.yaml
+++ b/.github/workflows/release-web.yaml
@@ -18,6 +18,11 @@ on:
         description: 'Release version'
         required: true
         type: string
+    secrets:
+      NETLIFY_SITE_ID:
+        required: true
+      NETLIFY_AUTH_TOKEN:
+        required: true
 
 concurrency: deploy-to-production
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,13 +124,26 @@ jobs:
           path: dist/
           retention-days: 1
 
-      - name: Debug CrabNebula release command
+      - name: Validate release outputs
         run: |
-          echo "generate-release-version outputs v2:"
+          echo "generate-release-version outputs:"
           echo "release-version: ${{ steps.generate-release-version.outputs.release-version }}"
           echo "release-tag: ${{ steps.generate-release-version.outputs.release-tag }}"
           echo "release-notes: ${{ steps.generate-release-version.outputs.release-notes }}"
           echo "release-channel: ${{ steps.generate-release-version.outputs.release-channel }}"
+
+          # Validate required outputs
+          if [ -z "${{ steps.generate-release-version.outputs.release-version }}" ]; then
+            echo "❌ Error: release-version is empty"
+            exit 1
+          fi
+
+          if [ -z "${{ steps.generate-release-version.outputs.release-tag }}" ]; then
+            echo "❌ Error: release-tag is empty"
+            exit 1
+          fi
+
+          echo "✅ All required release outputs are present"
 
       - name: Create draft CrabNebula release
         uses: crabnebula-dev/cloud-release@v0.2.0
@@ -187,7 +200,9 @@ jobs:
           echo "Release commit: $RELEASE_COMMIT"
 
           # Cherry-pick the release commit into main (without merge history)
-          git cherry-pick $RELEASE_COMMIT --no-commit
+          # Use -X theirs to automatically resolve conflicts in favor of the release branch
+          git cherry-pick $RELEASE_COMMIT --no-commit -X theirs
+
           git commit -m "chore: sync stable release $VERSION to main [skip ci]
 
           This commit syncs the stable release version back to main branch

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "algokit-lora"
-version = "2.0.0-beta.2"
+version = "2.0.0-beta.6"
 dependencies = [
  "serde",
  "serde_json",


### PR DESCRIPTION
There are currently errors in  the promote-to-prod workflow when running the release workflow. The release-desktop and release-web workflows are called from the release workflow, which means the secrets are passed automatically. The secrets were already being inherited but not imported by the workflow, so i added them. 

These are some other updates
- Added validation for missing release outputs that are needed crabnebula steps
- Updated the conflict resolution in the sync-to-main job because it was failing on merge conflicts.