### PR TITLE
chore: update version sync to refresh cargo lock

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "algokit-lora"
-version = "2.0.4"
+version = "2.0.7"
 dependencies = [
  "serde",
  "serde_json",


### PR DESCRIPTION
 The cargo lock file wasn't getting the version update applied when syncing.
 This change updates the version sync script to handle updating the cargo lock file.