### PR TITLE
feat: support rendering metadata for asset which don't complete conform to arc3

### DIFF
--- a/src/features/assets/mappers/asset.ts
+++ b/src/features/assets/mappers/asset.ts
@@ -114,7 +114,7 @@ const asStandardsUsed = (assetResult: AssetResult, metadataResult: AssetMetadata
   const standardsUsed = new Set<AssetStandard>()
 
   const [isArc3, isArc19] = assetResult.params.url
-    ? ([isArc3Url(assetResult.params.url), isArc19Url(assetResult.params.url)] as const)
+    ? ([isArc3Url(assetResult.params.url, assetResult.params.name), isArc19Url(assetResult.params.url)] as const)
     : [false, false]
   if (isArc3) {
     standardsUsed.add(AssetStandard.ARC3)

--- a/src/features/assets/utils/arc3.ts
+++ b/src/features/assets/utils/arc3.ts
@@ -1,8 +1,13 @@
 import { AssetId } from '../data/types'
 
-// When the URL contains #arc3 or @arc3, it follows ARC-3
-export const isArc3Url = (assetUrl: string) => assetUrl.includes('#arc3') || assetUrl.includes('@arc3')
+// Check if the asset details follow ARC-3
+export const isArc3Url = (assetUrl: string, assetName?: string) =>
+  assetUrl.endsWith('#arc3') || (assetName && (assetName === 'arc3' || assetName.endsWith('@arc3')))
 
 export const getArc3Url = (assetId: AssetId, url: string): string => {
-  return url.replace('{id}', assetId.toString())
+  let result = url.replace('{id}', assetId.toString())
+  if (result.endsWith('#arc3')) {
+    result = result.slice(0, -5)
+  }
+  return result
 }

--- a/src/tests/object-mother/application-result.ts
+++ b/src/tests/object-mother/application-result.ts
@@ -224,6 +224,60 @@ export const applicationResultMother = {
       },
     })
   },
+  ['mainnet-2849426479']: () => {
+    return new ApplicationResultBuilder({
+      id: 2849426479n,
+      params: {
+        approvalProgram: base64ToBytes(
+          'CiADAAEgJgQIYXNzZXRfaWQRbm90LWNpcmN1bGF0aW5nLTERbm90LWNpcmN1bGF0aW5nLTIRbm90LWNpcmN1bGF0aW5nLTMxGEAADygiZykyA2cqMgNnKzIDZzEbQQBdggMEcJuAqAQLYscoBFzCxTU2GgCOAwAxABwAAiJDMRkURDEYRDYaAReIAJcWgAQVH3x1TFCwI0MxGRREMRhENhoBNhoCVwIAiAA9I0MxGRREMRhENhoBF4gADSNDMRlA/7oxGBREI0OKAQAxAIv/cQdEEkEADiIoZURAAAcjRCiL/2eJIkL/9ooCACIoZUQxAEsBcQdEEkSL/kxwAEUBRCkqK4v/jgMACwAGAAEAK4v+Z4kqi/5niSmL/meJigEBgABHAiIpZUQiKmVEIitlRCIoZUSL/xJEi/9xCEQyAxJAAA6L/3EIRIv/cABFAUAAeCKMAosDMgMSQAALiwOL/3AARQFAAFYijACLBDIDEkAAC4sEi/9wAEUBQAA0IowBiwUyAxJAAAuLBYv/cABFAUAAFCKL/3EARIsCCYsACYsBCUwJjACJiwWL/3AAREL/44sEi/9wAESMAUL/w4sDi/9wAESMAEL/oYv/cQhEi/9wAESMAkL/fA=='
+        ),
+        clearStateProgram: base64ToBytes('CoEBQw=='),
+        creator: algosdk.Address.fromString('5BBRF536WPMEJJMGHLD677FGYW4ELDYXPXBQAWCLNNJZ6RAOCEALFXRWOU'),
+        globalState: [
+          toTealKeyValue({
+            key: 'YXNzZXRfaWQ=',
+            value: {
+              bytes: '',
+              type: 2,
+              uint: 2849506951,
+            },
+          }),
+          toTealKeyValue({
+            key: 'bm90LWNpcmN1bGF0aW5nLTE=',
+            value: {
+              bytes: '6DKR56GFNNHN4KGNDMGSQGGHJPOYXHAIBCNIKD2MLSUIGVN6GZIJ4OA4Q4',
+              type: 1,
+              uint: 0,
+            },
+          }),
+          toTealKeyValue({
+            key: 'bm90LWNpcmN1bGF0aW5nLTI=',
+            value: {
+              bytes: '6DKR56GFNNHN4KGNDMGSQGGHJPOYXHAIBCNIKD2MLSUIGVN6GZIJ4OA4Q4',
+              type: 1,
+              uint: 0,
+            },
+          }),
+          toTealKeyValue({
+            key: 'bm90LWNpcmN1bGF0aW5nLTM=',
+            value: {
+              bytes: 'KK3AD72XX2Z7PIBJDU2B27DXC2XI3ZXZEXVHSM5JNV2OTKUTKDLOYUJ6I',
+              type: 1,
+              uint: 0,
+            },
+          }),
+        ],
+        globalStateSchema: {
+          numByteSlice: 3,
+          numUint: 1,
+        },
+        localStateSchema: {
+          numByteSlice: 0,
+          numUint: 0,
+        },
+      },
+    })
+  },
 }
 
 const toTealKeyValue = ({ key, value }: { key: string; value: { type: number; uint: number; bytes: string } }) =>

--- a/src/tests/object-mother/asset-result.ts
+++ b/src/tests/object-mother/asset-result.ts
@@ -712,4 +712,25 @@ export const assetResultMother = {
       },
     })
   },
+  ['mainnet-2849506951']: () => {
+    return new AssetResultBuilder({
+      index: 2849506951n,
+      params: {
+        clawback: '6DKR56GFNNHN4KGNDMGSQGGHJPOYXHAIBCNIKD2MLSUIGVN6GZIJ4OA4Q4',
+        creator: '5BBRF536WPMEJJMGHLD677FGYW4ELDYXPXBQAWCLNNJZ6RAOCEALFXRWOU',
+        decimals: 9,
+        defaultFrozen: false,
+        freeze: '6DKR56GFNNHN4KGNDMGSQGGHJPOYXHAIBCNIKD2MLSUIGVN6GZIJ4OA4Q4',
+        manager: '6DKR56GFNNHN4KGNDMGSQGGHJPOYXHAIBCNIKD2MLSUIGVN6GZIJ4OA4Q4',
+        name: 'Midas US Treasury Bill Token',
+        nameB64: encoder.encode('TWlkYXMgVVMgVHJlYXN1cnkgQmlsbCBUb2tlbg=='),
+        reserve: 'KK3AD72XX2Z7PIBJDU2B27DXC2XI3ZXZEXVHSM5JNV2OTKUTKDLOYUJ6I',
+        total: 18446744073709551615n,
+        unitName: 'mTBILL',
+        unitNameB64: encoder.encode('bVRCSUxM'),
+        url: 'ipfs://bafkreifh2ih4gww2zcmi5cjpzalhqgkeyzbfdyqcgm6fjbzfj7mpvvgcbu',
+        urlB64: encoder.encode('aXBmczovL2JhZmtyZWlmaDJpaDRnd3cyemNtaTVjanB6YWxocWdrZXl6YmZkeXFjZ202ZmpiemZqN21wdnZnY2J1'),
+      },
+    } satisfies AssetResult)
+  },
 }


### PR DESCRIPTION
Whilst collaborating on the arc62 PR, I noticed that the "Midas US Treasury Bill Token" asset listed in https://arc.algorand.foundation/assets/arc-0062/ doesn't completely conform to ARC-3 (no #arc3 suffix on the metadata url) and as a result lora wasn't detecting it as an ARC-62 asset.

This PR relaxes the ARC-3 metadata fetching mechanism to try resolve metadata for assets with IPFS urls that return JSON, however don't explicitly have the `#arc3` suffix defined.

Note: This PR is currently based against #496, however will be retargeted once that PR merges.