### PR TITLE
feature: added circle usdc faucet link to testnet dispenser

### DIFF
--- a/src/features/fund/components/dispenser-api-logged-in.tsx
+++ b/src/features/fund/components/dispenser-api-logged-in.tsx
@@ -26,7 +26,7 @@ export function DispenserApiLoggedIn({ networkConfig }: Props) {
           <DispenserApiUserInfo />
           <Accordion type="single" collapsible defaultValue="fund">
             <AccordionItem value="fund">
-              <AccordionTrigger>Fund an existing {networkConfig.name} account</AccordionTrigger>
+              <AccordionTrigger>Fund an existing {networkConfig.name} account with ALGO</AccordionTrigger>
               <AccordionContent>
                 <FundAccountForm onSubmit={fundAccount} limit={fundLimit} defaultReceiver={activeWalletAccountSnapshot?.address} />
               </AccordionContent>
@@ -49,6 +49,22 @@ export function DispenserApiLoggedIn({ networkConfig }: Props) {
                     return <p>This action requires a connected wallet</p>
                   }}
                 </RenderLoadable>
+              </AccordionContent>
+            </AccordionItem>
+            <AccordionItem value="usdc">
+              <AccordionTrigger>Fund an existing TestNet account with USDC</AccordionTrigger>
+              <AccordionContent>
+                <p>
+                  To fund your TestNet account with USDC, use the{' '}
+                  <a
+                    href="https://faucet.circle.com/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary underline hover:no-underline"
+                  >
+                    Circle TestNet Faucet
+                  </a>{' '}
+                </p>
               </AccordionContent>
             </AccordionItem>
           </Accordion>

--- a/src/features/fund/fund-page.test.tsx
+++ b/src/features/fund/fund-page.test.tsx
@@ -112,8 +112,9 @@ describe('fund-page', () => {
           ),
         async (component) => {
           await waitFor(() => {
-            expect(component.getByText('Fund an existing TestNet account')).toBeTruthy()
+            expect(component.getByText('Fund an existing TestNet account with ALGO')).toBeTruthy()
             expect(component.getByText('Refund unused TestNet ALGO')).toBeTruthy()
+            expect(component.getByText('Fund an existing TestNet account with USDC')).toBeTruthy()
           })
         }
       )


### PR DESCRIPTION
Added Circle TestNet dispenser url to the funding TestNet page

<img width="1323" height="882" alt="image" src="https://github.com/user-attachments/assets/29ac5202-a2d5-4e92-891b-5635e9a53822" />
