### PR TITLE
fix: Decoded ABI Args now render an address the same as an account

### DIFF
--- a/src/features/abi-methods/components/decoded-abi-method-arguments.tsx
+++ b/src/features/abi-methods/components/decoded-abi-method-arguments.tsx
@@ -19,6 +19,12 @@ export function DecodedAbiMethodArguments({ arguments: argumentsProp, multiline 
           {argument.value}
         </TransactionLink>
       )
+    } else if (argument.type === DecodedAbiType.Address) {
+      return (
+        <AddressOrNfdLink className="text-primary underline" address={argument.value}>
+          {argument.value}
+        </AddressOrNfdLink>
+      )
     } else if (argument.type === DecodedAbiType.Account) {
       return (
         <AddressOrNfdLink className="text-primary underline" address={argument.value}>


### PR DESCRIPTION
There's probably a better way to do this, but I didn't want to modify `decoded-abi-values.tsx` in case it had knock-on effects elsewhere.

Before:
<img width="687" height="435" alt="Screenshot 2025-11-20 at 10 57 38" src="https://github.com/user-attachments/assets/f905555f-3a7f-4475-b13d-0e50356e6d7c" />

After:
<img width="692" height="395" alt="Screenshot 2025-11-20 at 10 57 50" src="https://github.com/user-attachments/assets/634bacbe-a34d-44be-acfa-b09b4e7c1faa" />
