### PR TITLE
fix: use new-release-version rather than new-release-git-tag, which does not exist

### DIFF
--- a/.github/actions/generate-release-version/action.yaml
+++ b/.github/actions/generate-release-version/action.yaml
@@ -56,7 +56,6 @@ runs:
         echo "=== Debugging semantic-release dry-run outputs ==="
         echo "new-release-published: '${{ steps.get-next-version.outputs.new-release-published }}'"
         echo "new-release-version: '${{ steps.get-next-version.outputs.new-release-version }}'"
-        echo "new-release-git-tag: '${{ steps.get-next-version.outputs.new-release-git-tag }}'"
         echo "=== All step outputs ==="
         echo '${{ toJSON(steps.get-next-version.outputs) }}'
         echo "=== Done debugging ==="
@@ -82,6 +81,6 @@ runs:
           const { data } = await github.rest.repos.getReleaseByTag({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            tag: "${{ steps.get-next-version.outputs.new-release-git-tag }}"
+            tag: "v${{ steps.get-next-version.outputs.new-release-version }}"
           })
           return data.id


### PR DESCRIPTION
The release pipeline was failing, which appears to be using an incorrect value in the GH action.

Based on the below failure debug output, `new-release-git-tag` is not a value that is ever set.
https://github.com/algorandfoundation/algokit-lora/actions/runs/19595587688/job/56119938956#step:8:183